### PR TITLE
feat: stop realtime update address balance

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,7 @@ import versionApi from './api/version';
 import helpers from './utils/helpers';
 import hathorLib from '@hathor/wallet-lib';
 import { BASE_URL } from './constants';
+import createRequestInstance from './api/customAxiosInstance';
 
 const store = new hathorLib.MemoryStore();
 hathorLib.storage.setStore(store);
@@ -50,6 +51,8 @@ const mapStateToProps = (state) => {
 class Root extends React.Component {
   componentDidMount() {
     WebSocketHandler.on('dashboard', this.handleWebsocket);
+
+    hathorLib.axios.registerNewCreateRequestInstance(createRequestInstance);
 
     versionApi.getVersion().then((data) => {
       this.props.isVersionAllowedUpdate({allowed: helpers.isVersionAllowed(data.version)});

--- a/src/api/customAxiosInstance.js
+++ b/src/api/customAxiosInstance.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import hathorLib from '@hathor/wallet-lib';
+
+/**
+ * Create axios instance settings base URL and content type  
+ * Besides that, it captures error to show modal error and save in Redux
+ *
+ * @module Axios
+ */
+
+/**
+ * Create an axios instance to be used when sending requests
+ *
+ * @param {callback} resolve Callback to be stored and used in case of a retry after a fail
+ * @param {number} timeout Timeout in milliseconds for the request
+ */
+const createRequestInstance = (resolve, timeout) => {
+  const instance = hathorLib.axios.defaultCreateRequestInstance(resolve, 30000);
+  return instance;
+}
+
+export default createRequestInstance;

--- a/src/api/customAxiosInstance.js
+++ b/src/api/customAxiosInstance.js
@@ -8,8 +8,7 @@
 import hathorLib from '@hathor/wallet-lib';
 
 /**
- * Create axios instance settings base URL and content type  
- * Besides that, it captures error to show modal error and save in Redux
+ * Create axios instance to be used in lib HTTP requests
  *
  * @module Axios
  */
@@ -21,6 +20,7 @@ import hathorLib from '@hathor/wallet-lib';
  * @param {number} timeout Timeout in milliseconds for the request
  */
 const createRequestInstance = (resolve, timeout) => {
+  // Will override lib axios instance increasing the default request timeout
   const instance = hathorLib.axios.defaultCreateRequestInstance(resolve, 30000);
   return instance;
 }

--- a/src/screens/AddressDetail.js
+++ b/src/screens/AddressDetail.js
@@ -80,7 +80,13 @@ class AddressDetail extends React.Component {
       if (queryParams.token !== this.state.queryParams.token && queryParams.token !== null) {
         // User selected a new token, so we must go to the first page (clear queryParams)
         this.pagination.clearOptionalQueryParams();
-        this.getHistoryData(this.pagination.obtainQueryParams());
+        // Need to get newQueryParams because the optional ones were cleared
+        // Update state to set the new selected token on it
+        // If we don't update this state here we might execute a duplicate request
+        const newQueryParams = this.pagination.obtainQueryParams();
+        this.setState({ queryParams: newQueryParams }, () => {
+          this.getHistoryData(newQueryParams);
+        });
         return;
       }
 

--- a/src/screens/AddressDetail.js
+++ b/src/screens/AddressDetail.js
@@ -39,6 +39,7 @@ class AddressDetail extends React.Component {
    * loadingSummary {boolean} If is waiting response of data summary request
    * loadingHistory {boolean} If is waiting response of data history request
    * errorMessage {String} message to be shown in case of an error
+   * warningRefreshPage {boolean} If should show a warning to refresh the page to see newest data for the address
    */
   state = {
     address: null,
@@ -52,6 +53,7 @@ class AddressDetail extends React.Component {
     loadingSummary: true,
     loadingHistory: false,
     errorMessage: '',
+    warningRefreshPage: false,
   }
 
   componentDidMount() {
@@ -105,14 +107,9 @@ class AddressDetail extends React.Component {
    */
   handleWebsocket = (wsData) => {
     if (wsData.type === 'network:new_tx_accepted') {
-      if (this.shouldUpdate(wsData, false)) {
-        // For summary data we don't check the token
-        this.getSummaryData();
-      }
-
-      if (this.shouldUpdate(wsData, true)) {
-        // For the history list we must check the token
-        this.updateListWs(wsData);
+      if (this.shouldUpdate(wsData, false) && !this.state.warningRefreshPage) {
+        // If the search address is in one of the inputs or outputs
+        this.setState({ warningRefreshPage: true });
       }
     }
   }
@@ -336,6 +333,7 @@ class AddressDetail extends React.Component {
         } else {
           return (
             <div>
+              {this.state.warningRefreshPage && <div className="alert alert-warning" role="alert"> There is a new transaction for this address. Please refresh the page to see the newest data.</div>}
               <AddressSummary
                 address={this.state.address}
                 balance={this.state.balance}


### PR DESCRIPTION
There are 3 changes in this PR:

1. Stop real time update of address balance and show a warning message that there is a new transaction for the address.

![image](https://user-images.githubusercontent.com/3298774/92194210-8252bf00-ee40-11ea-90b5-e5538ca4ee89.png)

2. Sometimes the address search request was being called twice when searching, depending on the response time of the first request.

3. The address search screen is composed of a Balance component and a History component. Each component has a request (one to get the balance of the address and another one to get the history - this last one with pagination).

Both requests take a long time depending on the number of transactions, in my tests I had them taking ~5s each. Given that both request are sent almost on the same time, the explorer axios timeout is 10s and the executes the second request only after the first one, most of the time I couldn't get the history because I received a timeout.

I customized our lib axios to increase the timeout right now because I think it's bad for this to happen to the explorer user, however I believe we should take a look why the requests are taking this long to reply.

I could've changed the code to request the history only after the balance arrived but this wouldn't solve the problem completely because soon we will have addresses with more txs and we will have the problem again. So I believe we should just increase the timeout for now while we improve the endpoints performance on the full node, then reduce the timeout again, what do you think?
