### PR TITLE
feat: show quantity of transaction inputs and outputs in transaction detail screen

### DIFF
--- a/src/components/TxData.js
+++ b/src/components/TxData.js
@@ -472,11 +472,11 @@ class TxData extends React.Component {
           </div>
           <div className="d-flex flex-column flex-lg-row align-items-start mb-3 w-100">
             <div className="f-flex flex-column align-items-start common-div bordered-wrapper mr-lg-3 w-100">
-              <div><label>Inputs:</label></div>
+              <div><label>Inputs ({ this.props.transaction.inputs.length })</label></div>
               {renderInputs(this.props.transaction.inputs)}
             </div>
             <div className="d-flex flex-column align-items-center common-div bordered-wrapper mt-3 mt-lg-0 w-100">
-              <div><label>Outputs:</label></div>
+              <div><label>Outputs ({ this.props.transaction.outputs.length })</label></div>
               {renderOutputs(this.props.transaction.outputs)}
             </div>
           </div>


### PR DESCRIPTION
## Motivation

There are some transactions that have many inputs/outputs and would be great to easily know how many of them we have.

Old screen:

![image](https://user-images.githubusercontent.com/3298774/128926455-6cc118e8-0c00-4c57-9523-0b604d11c9c6.png)

New screen:

1

![image](https://user-images.githubusercontent.com/3298774/128926481-e61753b8-155c-4755-8147-a9e0d243623f.png)

OR 

2

![image](https://user-images.githubusercontent.com/3298774/128926935-6bd14c97-65df-436e-862b-614541bf9dbb.png)

