### PR TITLE
feat: format statistics values with thousand separator

### DIFF
--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -40,10 +40,10 @@ class Dashboard extends React.Component {
 
     return (
       <div className="content-wrapper">
-        <p><strong>Blocks: </strong>{blocks}</p>
-        <p><strong>Height of the best chain: </strong>{height}</p>
-        <p><strong>Transactions: </strong>{transactions}</p>
-        <p><strong>Peers: </strong>{peers}</p>
+        <p><strong>Blocks: </strong>{helpers.renderValue(blocks, true)}</p>
+        <p><strong>Height of the best chain: </strong>{helpers.renderValue(height, true)}</p>
+        <p><strong>Transactions: </strong>{helpers.renderValue(transactions, true)}</p>
+        <p><strong>Peers: </strong>{helpers.renderValue(peers, true)}</p>
         <p className="color-hathor"><strong>Hash rate: </strong>{hashRate}</p>
       </div>
     );


### PR DESCRIPTION
### Acceptance criteria

Integers values should be formatted with thousand separator in Statistics screen.

![image](https://user-images.githubusercontent.com/3298774/135337975-8cd41808-21cc-490e-a3de-1421642ee295.png)
