### PR TITLE
fix: address page loading forever when changing tokens

### DIFF
--- a/src/screens/AddressDetail.js
+++ b/src/screens/AddressDetail.js
@@ -179,10 +179,12 @@ class AddressDetail extends React.Component {
    * @param {Object} queryParams URL parameters
    */
   getHistoryData = (queryParams) => {
-    addressApi.search(this.state.address, TX_COUNT, queryParams.hash, queryParams.page, queryParams.token, (response) => {
+    addressApi.search(this.state.address, TX_COUNT, queryParams.hash, queryParams.page, queryParams.token).then((response) => {
       if (response.success) {
         this.handleFetchedData(response, queryParams);
       }
+      // fetch metadata for selected token
+      this.getSelectedTokenMetadata(queryParams.token);
     });
   }
 
@@ -229,7 +231,7 @@ class AddressDetail extends React.Component {
    * Request data from server and update state balance
    */
   getSummaryData = () => {
-    addressApi.getBalance(this.state.address, (response) => {
+    addressApi.getBalance(this.state.address).then((response) => {
       if (response.success) {
         let selectedToken = '';
         if (this.state.selectedToken && this.state.selectedToken in response.tokens_data) {


### PR DESCRIPTION
# Acceptance criteria

- Address page will use explorer-service
- Address page on change token will load new token metadata

closes #133 