### PR TITLE
fix: network page peer goes undefined during deploy

### DIFF
--- a/src/api/networkApi.js
+++ b/src/api/networkApi.js
@@ -10,6 +10,9 @@ import { requestExplorerServiceV1 } from './axiosInstance';
 const networkApi = {
   getPeerList() {
     return requestExplorerServiceV1().get(`node`).then((res) => {
+      if (!res.data) {
+        throw new Error("unknown_error");
+      }
       return res.data
     }).catch((res) => {
       throw new Error(res.data.message);
@@ -17,6 +20,9 @@ const networkApi = {
   },
   getPeer(hash) {
     return requestExplorerServiceV1().get(`node/${hash}`).then((res) => {
+      if (!res.data) {
+        throw new Error("unknown_error");
+      }
       return res.data
     }).catch((res) => {
       throw new Error(res.data.message);

--- a/src/components/Network.js
+++ b/src/components/Network.js
@@ -48,6 +48,9 @@ class Network extends React.Component {
     const { match: { params } } = this.props;
 
     networkApi.getPeerList().then((peers) => {
+      if (peers.error === undefined && peers.length === 0) {
+        throw new Error("No peers present.");
+      }
       this.setState({peers}, () => {
         let peerId = peers.find(target => target === params.peerId);
         if (!peerId) {
@@ -55,7 +58,8 @@ class Network extends React.Component {
         }
         this.onPeerChange(peerId);
       });
-    }).catch(() => {
+    }).catch((ex) => {
+      console.log(ex);
       setTimeout(this.loadPeers.bind(this), 1000);
     });
   }


### PR DESCRIPTION
#128 

This will not resolve the problem of the daemon not registering the keys, but it will prevent the peer to be `undefined` when the list of peers goes empty.