### PR TITLE
feat: decode output script data in the tx detail screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1124,9 +1124,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.27.0.tgz",
-      "integrity": "sha512-syvoKDRqTMZdGj/7J7DO9c1FnB/+YHHHqnCD5pi0iZCN9rrCJzgYh1xC9VTa4zkeiveV1SVwpEMzQ+F27s+4TA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.29.0.tgz",
+      "integrity": "sha512-63MsrIV5M0DPBRJtgBm8QACieBdrZTDNB2rcce+wC1NIVk3lbdL/6ob2HcH99aJQYlSZ3IQWxA21ODJN7MagNQ==",
       "requires": {
         "axios": "^0.18.0",
         "bitcore-lib": "^8.25.10",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.0",
   "private": true,
   "dependencies": {
-    "@hathor/wallet-lib": "^0.27.0",
+    "@hathor/wallet-lib": "^0.29.0",
     "axios": "^0.17.1",
     "bootstrap": "^4.0.0",
     "d3-selection": "^1.3.2",

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -279,12 +279,29 @@ class TxData extends React.Component {
           return renderNanoContractMatchValues(output.decoded);
         default:
           let script = output.script;
+          // Try to parse as script data
+          try {
+            // The output script is decoded to base64 in the full node
+            // before returning as response to the explorer in the API
+            // and the lib expects a buffer (bytes)
+            // In the future we must receive from the full node
+            // the decoded.type as script data but this still needs
+            // some refactor there that won't happen soon
+            const buff = new Buffer.from(script, 'base64');
+            const parsedData = hathorLib.scriptsUtils.parseScriptData(buff);
+            return renderDataScript(parsedData.data);
+          } catch {}
+
           try {
             script = atob(output.script)
           } catch {}
 
           return `Unable to decode script: ${script.trim()}`;
       }
+    }
+
+    const renderDataScript = (data) => {
+      return `${data} [Data Script]`;
     }
 
     const renderP2PKHorMultiSig = (decoded) => {

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -290,7 +290,13 @@ class TxData extends React.Component {
             const buff = new Buffer.from(script, 'base64');
             const parsedData = hathorLib.scriptsUtils.parseScriptData(buff);
             return renderDataScript(parsedData.data);
-          } catch {}
+          } catch(e) {
+            if (!(e instanceof hathorLib.errors.ParseScriptError)) {
+              // Parse script error is the expected error in case the output script
+              // is not a script data. If we get another error here, we should at least log it
+              console.log('Error parsing script data', e);
+            }
+          }
 
           try {
             script = atob(output.script)

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -301,7 +301,7 @@ class TxData extends React.Component {
     }
 
     const renderDataScript = (data) => {
-      return `${data} [Data Script]`;
+      return `${data} [Data]`;
     }
 
     const renderP2PKHorMultiSig = (decoded) => {

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -294,7 +294,7 @@ class TxData extends React.Component {
             if (!(e instanceof hathorLib.errors.ParseScriptError)) {
               // Parse script error is the expected error in case the output script
               // is not a script data. If we get another error here, we should at least log it
-              console.log('Error parsing script data', e);
+              console.log('Unexpected error', e);
             }
           }
 


### PR DESCRIPTION
### Acceptance criteria

- Output script data shouldn't show 'unable to decode' anymore, so any NFT creation tx will show the decoded script data.

### TODO

- Bump wallet lib version after release

Old screen
![image](https://user-images.githubusercontent.com/3298774/144079411-ad7247ea-868e-4314-a17a-d3315c118521.png)

New screen
![image](https://user-images.githubusercontent.com/3298774/144079432-92828ca3-7217-480c-9e61-c663a9c0b585.png)
