### PR TITLE
chore: using node version 13 in github workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Node.js 14.x
+      - name: Set up Node.js 13.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 13.x
       - name: Cache node modules
         uses: actions/cache@v2
         env:


### PR DESCRIPTION
### Motivation

After the release of v0.10.0 we had a problem with the deploy of the explorer version. https://github.com/HathorNetwork/hathor-explorer/runs/4432263445?check_suite_focus=true

```
> hathor-admin@0.10.0 build-css
> node-sass-chokidar src/ -o src/

/home/runner/work/hathor-explorer/hathor-explorer/node_modules/node-sass/lib/binding.js:13
      throw new Error(errors.unsupportedEnvironment());
      ^

Error: Node Sass does not yet support your current environment: Linux 64-bit with Unsupported runtime (93)
For more information on which environments are supported please see:
https://github.com/sass/node-sass/releases/tag/v4.13.1
    at module.exports (/home/runner/work/hathor-explorer/hathor-explorer/node_modules/node-sass/lib/binding.js:13:13)
    at Object.<anonymous> (/home/runner/work/hathor-explorer/hathor-explorer/node_modules/node-sass/lib/index.js:14:35)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/home/runner/work/hathor-explorer/hathor-explorer/node_modules/node-sass-chokidar/bin/node-sass-chokidar:18:9)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
ERROR: "build-css" exited with 1.
make: *** [Makefile:26: mainnet_build] Error 1
Error: Process completed with exit code 2.
```

The node-sass package could not be installed and the link with supported versions (https://github.com/sass/node-sass/releases/tag/v4.13.1) shows that this package does not support node 14

![image](https://user-images.githubusercontent.com/3298774/144875539-c6221104-f409-4a6b-8e91-f3772ea47960.png)