### PR TITLE
feat: we must support using an optional field in the token metadata: content_type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ clear_cloudfront_cache:
 
 .PHONY: testnet_local
 testnet_local:
-	FULLNODE_HOST=node1.golf.testnet.hathor.network; \
+	FULLNODE_HOST=node1.testnet.hathor.network; \
 	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
 	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
 	export REACT_APP_EXPLORER_SERVICE_BASE_URL=http://localhost:3001/dev/; \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ check_tag:
 
 .PHONY: testnet_build
 testnet_build:
-	FULLNODE_HOST=node1.golf.testnet.hathor.network; \
+	FULLNODE_HOST=node1.testnet.hathor.network; \
 	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
 	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
 	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.testnet.hathor.network/; \

--- a/src/components/token/TokenNFTPreview.js
+++ b/src/components/token/TokenNFTPreview.js
@@ -34,7 +34,9 @@ const TokenNFTPreview = (props) => {
 
   const nftType = token.meta.nft_media.type && token.meta.nft_media.type.toUpperCase();
 
-  const ext = helpers.getFileExtension(token.meta.nft_media.file);
+  // The metadata may have the media content type (useful for videos and audios) because many times the file does not have an extension.
+  // In case it's not there, we try to get from the file extension
+  const ext = token.meta.nft_media.content_type || helpers.getFileExtension(token.meta.nft_media.file);
 
   let fileType;
 

--- a/src/components/token/TokenNFTPreview.js
+++ b/src/components/token/TokenNFTPreview.js
@@ -34,18 +34,23 @@ const TokenNFTPreview = (props) => {
 
   const nftType = token.meta.nft_media.type && token.meta.nft_media.type.toUpperCase();
 
-  // The metadata may have the media content type (useful for videos and audios) because many times the file does not have an extension.
+  // The metadata may have the media mime type (useful for videos and audios) because many times the file does not have an extension.
   // In case it's not there, we try to get from the file extension
-  const ext = token.meta.nft_media.content_type || helpers.getFileExtension(token.meta.nft_media.file);
+  // mimeType will already have image/png, video/mp4, application/pdf, audio/mp3
+  // so we don't need to handle anything if it's already set
+  const mimeType = token.meta.nft_media.mime_type;
 
-  let fileType;
+  let fileType = mimeType;
+  if (!fileType) {
+    const ext = helpers.getFileExtension(token.meta.nft_media.file);
 
-  if (nftType === NFT_MEDIA_TYPES.audio) {
-    fileType = AUDIO_MEDIA_TYPES_BY_EXTENSION[ext];
-  }
+    if (nftType === NFT_MEDIA_TYPES.audio) {
+      fileType = AUDIO_MEDIA_TYPES_BY_EXTENSION[ext];
+    }
 
-  if (nftType === NFT_MEDIA_TYPES.video) {
-    fileType = VIDEO_MEDIA_TYPES_BY_EXTENSION[ext];
+    if (nftType === NFT_MEDIA_TYPES.video) {
+      fileType = VIDEO_MEDIA_TYPES_BY_EXTENSION[ext];
+    }
   }
 
   let media;


### PR DESCRIPTION
### Motivation

Many ipfs files don't have extension, so the explorer failed to show the preview for videos and audios in this situation.

Reference issue: https://github.com/HathorNetwork/hathor-nft-review/issues/56

### Acceptance criteria

The explorer must support a new optional field in the tokens metadata `mime_type`, e.g. video/mp4, image/png, application/pdf, .... We use this field in the client to set the media source instead of using extension, which is limited. This is better than having the content type only (mp4, mp3, ...) because we can directly use it to render the media in the client.

Note:

I've updated the testnet URL in the Makefile to use `node1.testnet.` instead of `node1.golf.testnet`, so we don't need to update it every new testnet release.