### PR TITLE
feat(statistics): remove 'Blocks' and rename 'Height of the best chain' info (#159)

### DIFF
--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -27,7 +27,6 @@ class Dashboard extends React.Component {
       );
     }
 
-    const blocks = this.props.data.blocks;
     const transactions = this.props.data.transactions;
     const height = this.props.data.best_block_height;
 
@@ -39,8 +38,7 @@ class Dashboard extends React.Component {
 
     return (
       <div className="content-wrapper">
-        <p><strong>Blocks: </strong>{helpers.renderValue(blocks, true)}</p>
-        <p><strong>Height of the best chain: </strong>{helpers.renderValue(height, true)}</p>
+        <p><strong>Blocks (best height): </strong>{helpers.renderValue(height, true)}</p>
         <p><strong>Transactions: </strong>{helpers.renderValue(transactions, true)}</p>
         <p className="color-hathor"><strong>Hash rate: </strong>{hashRate}</p>
       </div>


### PR DESCRIPTION
### Motivation

To give a better user experience on statistics page, we are removing "Blocks" line and renaming "Height of the best chain" to "Blocks (best height)".

### Acceptance criteria

The Explorer must render the statistics page as this screenshot:

<img width="1055" alt="Screen Shot 2022-01-27 at 16 43 08" src="https://user-images.githubusercontent.com/3287486/151433747-a18f75be-3ff7-4a5e-8303-1911c05bcf9b.png">

