### PR TITLE
feat(transactions): load neighbors graphs only when requested by user (#158)

### DIFF
--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -137,12 +137,11 @@ class TxData extends React.Component {
   calculateNeighborsGraph = async (graphType) => {
     const viz = new Viz({ Module, render });
 
-    await graphvizApi.dotNeighbors(this.props.transaction.hash, graphType).then(response => {
-      viz.renderSVGElement(response).then((element) => {
-          element.id = `graph-${graphType}`;
-          document.getElementById(`graph-${graphType}`).appendChild(element);
-      });
-    });
+    const graphvizResponse = await graphvizApi.dotNeighbors(this.props.transaction.hash, graphType);
+    const element = await viz.renderSVGElement(graphvizResponse);
+
+    element.id = `graph-${graphType}`;
+    document.getElementById(`graph-${graphType}`).appendChild(element);
   }
 
   /**
@@ -159,12 +158,15 @@ class TxData extends React.Component {
 
     this.setState({ graphs });
 
+    // Check if graph needs to be calculated before showing
     if(!graphs[index].calculatedNeighbors && !graphs[index].graphLoading) {
       graphs[index].graphLoading = true;
       this.setState({ graphs });
 
+      // Make the necessary requests to calculate the graph
       await this.calculateNeighborsGraph(graphs[index].name);
 
+      // Update graph status
       graphs[index].calculatedNeighbors = true;
       graphs[index].graphLoading = false;
       this.setState({ graphs });

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -140,7 +140,7 @@ class TxData extends React.Component {
     const graphvizResponse = await graphvizApi.dotNeighbors(this.props.transaction.hash, graphType);
     const element = await viz.renderSVGElement(graphvizResponse);
 
-    element.id = `graph-${graphType}`;
+    element.id = `graph-${graphType}-data`;
     document.getElementById(`graph-${graphType}`).appendChild(element);
   }
 
@@ -464,7 +464,7 @@ class TxData extends React.Component {
     const renderGraph = (graphIndex) => {
       return (
         <div className="d-flex flex-column flex-lg-row align-items-start mb-3 common-div bordered-wrapper w-100">
-          <div className="mt-3 graph-div" id={`graph-neighbors`} key={`graph-${this.state.graphs[graphIndex].name}-${this.props.transaction.hash}`}>
+          <div className="mt-3 graph-div" key={`graph-${this.state.graphs[graphIndex].name}-${this.props.transaction.hash}`}>
             <label className="graph-label">{this.state.graphs[graphIndex].label}:</label>
             <a href="true" className="ml-1" onClick={(e) => this.toggleGraph(e, graphIndex)}>{this.state.graphs[graphIndex].showNeighbors ? 'Click to hide' : 'Click to show'}</a>
             <div className={this.state.graphs[graphIndex].showNeighbors ? undefined : 'd-none'} id={`graph-${this.state.graphs[graphIndex].name}`}></div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -410,10 +410,6 @@ p, span {
   width: 100%;
 }
 
-.hidden {
-  display:none;
-}
-
 .navbar-dark .navbar-toggler {
   border: 0;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -406,7 +406,7 @@ p, span {
   padding-left: 0;
 }
 
-#graph-funds svg, #graph-verification svg, #graph-neighbors svg {
+#graph-funds svg, #graph-verification svg {
   width: 100%;
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -406,8 +406,12 @@ p, span {
   padding-left: 0;
 }
 
-#graph-funds svg, #graph-verification svg {
+#graph-funds svg, #graph-verification svg, #graph-neighbors svg {
   width: 100%;
+}
+
+.hidden {
+  display:none;
 }
 
 .navbar-dark .navbar-toggler {

--- a/src/screens/DecodeTx.js
+++ b/src/screens/DecodeTx.js
@@ -89,7 +89,7 @@ class DecodeTx extends React.Component {
     return (
       <div className="content-wrapper">
         <TxTextInput onChange={this.handleChangeData} buttonClicked={this.buttonClicked} action='Decode tx' otherAction='push' link='/push-tx/' helpText='Write your transaction in hex value and click the button to get a human value description' />
-        {this.state.transaction ? <TxData transaction={this.state.transaction} showRaw={false} confirmationData={this.state.confirmationData} spentOutputs={this.state.spentOutputs} meta={this.state.meta} showConflicts={false} showGraphs={true} /> : null}
+        {this.state.transaction ? <TxData transaction={this.state.transaction} showRaw={false} confirmationData={this.state.confirmationData} spentOutputs={this.state.spentOutputs} meta={this.state.meta} showConflicts={false} /> : null}
         {this.state.success === false ? <p className="text-danger">Could not decode this data to a transaction</p> : null}
       </div>
     );

--- a/src/screens/TransactionDetail.js
+++ b/src/screens/TransactionDetail.js
@@ -123,7 +123,7 @@ class TransactionDetail extends React.Component {
     const renderTx = () => {
       return (
         <div>
-          {this.state.transaction ? <TxData transaction={this.state.transaction} confirmationData={this.state.confirmationData} spentOutputs={this.state.spentOutputs} meta={this.state.meta} showRaw={true} showConflicts={true} showGraphs={true} /> : <p className="text-danger">Transaction with hash {this.props.match.params.id} not found</p>}
+          {this.state.transaction ? <TxData transaction={this.state.transaction} confirmationData={this.state.confirmationData} spentOutputs={this.state.spentOutputs} meta={this.state.meta} showRaw={true} showConflicts={true} /> : <p className="text-danger">Transaction with hash {this.props.match.params.id} not found</p>}
         </div>
       );
     }


### PR DESCRIPTION
### Motivation

Today, when the user loads the transaction page, it automatically loads the neighbors graphs (verification and funds). If the user opens many transactions, the interface starts to slow down because of these automatically loaded graphs.

To solve this problem, a lazy loading mechanism was introduced. Now, the graph will only be loaded when user requests.

### Acceptance Criteria

User must be able to visualize neighbors graphs when clicking on "Click to show" and hiding it clicking on "Click to hide", as shown on this video:

Obs. A sleep of 5 seconds was intentionally placed to simulate a scenario where the full-node is taking too long to respond:

https://user-images.githubusercontent.com/3287486/151799933-a3af6eeb-df32-428d-acdb-cf4c9a6f3513.mov