### PR TITLE
chore: use new testnet fullnode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ check_tag:
 
 .PHONY: testnet_build
 testnet_build:
-	FULLNODE_HOST=node1.testnet.hathor.network; \
+	FULLNODE_HOST=node.explorer.testnet.hathor.network; \
 	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
 	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
 	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.testnet.hathor.network/; \
@@ -43,7 +43,7 @@ clear_cloudfront_cache:
 
 .PHONY: testnet_local
 testnet_local:
-	FULLNODE_HOST=node1.testnet.hathor.network; \
+	FULLNODE_HOST=node.explorer.testnet.hathor.network; \
 	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
 	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
 	export REACT_APP_EXPLORER_SERVICE_BASE_URL=http://localhost:3001/dev/; \


### PR DESCRIPTION
### Acceptance Criteria
- We should use the new `node-explorer` that was created in the Testnet.