### PR TITLE
feat: add token to the query params in the address list screen

### DIFF
--- a/src/components/token/TokenAutoCompleteField.js
+++ b/src/components/token/TokenAutoCompleteField.js
@@ -184,7 +184,7 @@ class TokenAutoCompleteField extends React.Component {
         value={this.state.searchText}
         onKeyUp={this.onSearchTextKeyUp}
         onChange={this.onSearchTextChanged}
-        placeholder="Search UID, name or symbol"
+        placeholder="Hathor (HTR) - Type to search for other tokens by UID, name or symbol"
         aria-label="Search"
         ref={ref => {this.autoCompleteInputRef = ref}} />
     )

--- a/src/components/token/TokenAutoCompleteField.js
+++ b/src/components/token/TokenAutoCompleteField.js
@@ -185,8 +185,7 @@ class TokenAutoCompleteField extends React.Component {
         onKeyUp={this.onSearchTextKeyUp}
         onChange={this.onSearchTextChanged}
         placeholder="Hathor (HTR) - Type to search for other tokens by UID, name or symbol"
-        aria-label="Search"
-        ref={ref => {this.autoCompleteInputRef = ref}} />
+        aria-label="Search" />
     )
   }
 

--- a/src/components/token/TokenAutoCompleteField.js
+++ b/src/components/token/TokenAutoCompleteField.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Loading from '../Loading';
 import tokensApi from '../../api/tokensApi';
 import { debounce, get } from 'lodash';
+import { constants as hathorLibConstants } from '@hathor/wallet-lib';
 
 const DEBOUNCE_SEARCH_TIME = 200; // ms
 
@@ -56,10 +57,34 @@ class TokenAutoCompleteField extends React.Component {
 
   componentDidMount() {
     document.addEventListener('click', this.handleClick);
+
+    if (this.props.tokenId !== hathorLibConstants.HATHOR_TOKEN_CONFIG.uid) {
+      // A token was selected in the query params
+      // so we must search for it here to add
+      // in the autocomplete input and perform the search
+      this.searchAndSelectToken(this.props.tokenId);
+    }
   }
 
   componentWillUnmount() {
     document.removeEventListener('click', this.handleClick);
+  }
+
+  /**
+   * The first component mount will need to find the token item in the elastic search
+   * and then execute the data search, in case a token was already selected in the query
+   *
+   * @param {string} tokenId The token to pre select when first mounting the component
+   */
+  searchAndSelectToken = async (tokenId) => {
+    const searchResults = await this.executeSearch(this.props.tokenId);
+
+    if (searchResults.length > 0) {
+      this.onItemSelected(searchResults[0]);
+    } else {
+      // The token uid in the query params didn't find any token
+      this.props.loadingFinished();
+    }
   }
 
   /**
@@ -86,7 +111,7 @@ class TokenAutoCompleteField extends React.Component {
       searchText: event.target.value,
     });
 
-    this.performSearch();
+    this.performSearchDebounce();
   }
 
   /**
@@ -106,7 +131,7 @@ class TokenAutoCompleteField extends React.Component {
    * Called from onSearchTextChanged after DEBOUNCE_SEARCH_TIME ms from
    * a keypress
    */
-  performSearch = debounce(async () => {
+  performSearchDebounce = debounce(async () => {
     if (!this.state.searchText) {
       this.setState({
         searchResults: [],
@@ -114,7 +139,21 @@ class TokenAutoCompleteField extends React.Component {
       return;
     }
 
-    const tokensRequest = await tokensApi.getList(this.state.searchText, 'transaction_timestamp', 'desc', []);
+    const searchResults = await this.executeSearch(this.state.searchText);
+
+    this.setState({
+      searchResults,
+    });
+
+  }, DEBOUNCE_SEARCH_TIME)
+
+  /**
+   * Execute explorer service search to find the list of tokens that match the search text
+   *
+   * @params {string} searchText Text written by the user in the search input
+   */
+  executeSearch = async (searchText) => {
+    const tokensRequest = await tokensApi.getList(searchText, 'transaction_timestamp', 'desc', []);
     this.setState({
       error: get(tokensRequest, 'error', false),
     });
@@ -122,10 +161,9 @@ class TokenAutoCompleteField extends React.Component {
     const tokens = get(tokensRequest, 'data', { hits: [], 'has_next': false });
     const searchResults = tokens.hits;
 
-    this.setState({
-      searchResults,
-    });
-  }, DEBOUNCE_SEARCH_TIME)
+    return searchResults;
+  }
+
 
   _renderInputForm() {
     if (this.state.selectedItem) {
@@ -165,7 +203,7 @@ class TokenAutoCompleteField extends React.Component {
     }
 
     return (
-      <i className="fa fa-search pointer" onClick={() => this.performSearch()} />
+      <i className="fa fa-search pointer" onClick={() => this.performSearchDebounce()} />
     );
   }
 

--- a/src/components/token/TokenAutoCompleteField.js
+++ b/src/components/token/TokenAutoCompleteField.js
@@ -62,7 +62,7 @@ class TokenAutoCompleteField extends React.Component {
       // A token was selected in the query params
       // so we must search for it here to add
       // in the autocomplete input and perform the search
-      this.searchAndSelectToken(this.props.tokenId);
+      this.searchAndSelectToken();
     }
   }
 
@@ -73,10 +73,8 @@ class TokenAutoCompleteField extends React.Component {
   /**
    * The first component mount will need to find the token item in the elastic search
    * and then execute the data search, in case a token was already selected in the query
-   *
-   * @param {string} tokenId The token to pre select when first mounting the component
    */
-  searchAndSelectToken = async (tokenId) => {
+  searchAndSelectToken = async () => {
     const searchResults = await this.executeSearch(this.props.tokenId);
 
     if (searchResults.length > 0) {

--- a/src/components/token/TokenBalances.js
+++ b/src/components/token/TokenBalances.js
@@ -18,7 +18,6 @@ import helpers from '../../utils/helpers';
 import { constants as hathorLibConstants } from '@hathor/wallet-lib';
 
 
-
 /**
  * Displays custom tokens in a table with pagination buttons and a search bar.
  */


### PR DESCRIPTION
### Acceptance criteria

- Address list must have the selected token in the query params, so we can share the link with it.

https://user-images.githubusercontent.com/3298774/173409762-a0ae4f97-cc0a-4d58-9b9f-f3689a1108cc.mov

- We must make it more clear that when there is nothing in the search, then we are showing the address list for HTR

This one is a bit tricky because the best approach would be to have HTR as a search element just like any other token. However, this would require much more changes in the code, then I feel this change is good enough for now with a simple UI change.

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/3298774/173413983-e463b2f0-99ee-479b-bc27-1e1949330323.png">
