### PR TITLE
fix: change timeseries iframe height

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -609,7 +609,7 @@ th.sortable {
 
 .timeseries-iframe {
   display: flex;
-  height: 600px;
+  height: 2300px;
   width: 100%;
   border: none;
 }


### PR DESCRIPTION
### Acceptance Criteria

Increase timeseries iframe height. So, at least for desktop, the iframe scrollbar does not appear, making the experience smoother.

### Testing

https://user-images.githubusercontent.com/3287486/176070932-2ed12fd9-35d0-408b-8040-51fa385941f2.mov


