### PR TITLE
refactor: using transactions count from the token entry instead of the tokenInformation API

### DIFF
--- a/src/api/tokensApi.js
+++ b/src/api/tokensApi.js
@@ -43,11 +43,7 @@ const tokensApi = {
    * @return {Promise}
    */
   async getToken(tokenId) {
-    const data = {
-      'token_id': tokenId,
-    };
-
-    const response = await requestExplorerServiceV1.get('token', { params: data, timeout: TOKENS_API_DEFAULT_TIMEOUT });
+    const response = await requestExplorerServiceV1.get(`tokens/${tokenId}`, { timeout: TOKENS_API_DEFAULT_TIMEOUT });
 
     return helpers.handleExplorerServiceResponse(response);
   },

--- a/src/api/tokensApi.js
+++ b/src/api/tokensApi.js
@@ -36,6 +36,23 @@ const tokensApi = {
   },
 
   /**
+   * Downloads a single token
+   *
+   * @param {String} tokenId The tokenId from the token we want to retrieve
+   *
+   * @return {Promise}
+   */
+  async getToken(tokenId) {
+    const data = {
+      'token_id': tokenId,
+    };
+
+    const response = await requestExplorerServiceV1.get('token', { params: data, timeout: TOKENS_API_DEFAULT_TIMEOUT });
+
+    return helpers.handleExplorerServiceResponse(response);
+  },
+
+  /**
    * Downloads a list of token balances given an token_id
    *
    * @param {String} tokenId Token id to filter token address balances

--- a/src/components/token/TokenBalances.js
+++ b/src/components/token/TokenBalances.js
@@ -236,7 +236,7 @@ class TokenBalances extends React.Component {
 
     this.setState({
       tokensApiError: get(tokenApiRequest, 'error', false),
-      transactionsCount: get(tokenApiRequest, 'data.hits[0].transactions', 0),
+      transactionsCount: get(tokenApiRequest, 'data.hits[0].transactions_count', 0),
     });
   }
 
@@ -256,7 +256,7 @@ class TokenBalances extends React.Component {
 
     await helpers.setStateAsync(this, {
       tokenId: token.id,
-      transactionsCount: token.transactions,
+      transactionsCount: token.transactions_count,
       tokensApiError: false,
     });
 
@@ -285,6 +285,13 @@ class TokenBalances extends React.Component {
    */
   loadingFinished = () => {
     this.setState({ loading: false });
+  }
+
+  onRetryTokensApi = () => {
+    this.setState({
+      tokensApiError: false,
+    });
+    this.fetchHTRTransactionCount();
   }
 
   render() {
@@ -331,21 +338,18 @@ class TokenBalances extends React.Component {
               </p>
             )
           }
-          {
-            !this.state.tokenBalanceInformationError && (
-              <>
-                <p><b>Total number of addresses:</b> { helpers.renderValue(this.state.addressesCount, true) }</p>
-                {!this.state.tokensApiError && (
-                  <p><b>Total number of transactions:</b> { helpers.renderValue(this.state.transactionsCount, true) }</p>
-                )}
-              </>
-            )
-          }
-          {
-            this.state.tokenBalanceInformationError && (
-              <ErrorMessageWithIcon message='Error loading token balance information. Please try again.' />
-            )
-          }
+
+          {!this.state.tokenBalanceInformationError && (
+            <p><b>Total number of addresses:</b> { helpers.renderValue(this.state.addressesCount, true) }</p>
+          )}
+
+          {!this.state.tokensApiError && (
+            <p><b>Total number of transactions:</b> { helpers.renderValue(this.state.transactionsCount, true) }</p>
+          )}
+
+          {(this.state.tokensApiError || this.state.tokenBalanceInformationError) &&(
+            <ErrorMessageWithIcon message='Error loading the complete token balance information. Please try again.' />
+          )}
         </div>
 
         {renderTokensTable()}

--- a/src/components/token/TokenBalances.js
+++ b/src/components/token/TokenBalances.js
@@ -232,7 +232,7 @@ class TokenBalances extends React.Component {
   }
 
   fetchHTRTransactionCount = async () => {
-    const tokenApiRequest = await tokensApi.getToken('00');
+    const tokenApiRequest = await tokensApi.getToken(hathorLibConstants.HATHOR_TOKEN_CONFIG.uid);
 
     this.setState({
       tokensApiError: get(tokenApiRequest, 'error', false),
@@ -285,13 +285,6 @@ class TokenBalances extends React.Component {
    */
   loadingFinished = () => {
     this.setState({ loading: false });
-  }
-
-  onRetryTokensApi = () => {
-    this.setState({
-      tokensApiError: false,
-    });
-    this.fetchHTRTransactionCount();
   }
 
   render() {

--- a/src/components/token/TokenBalances.js
+++ b/src/components/token/TokenBalances.js
@@ -96,6 +96,10 @@ class TokenBalances extends React.Component {
       // otherwise we just perform the search for HTR to show the default screen
       await this.performSearch();
 
+      // Since we did not search for the HTR token (it is the default), we need to fetch
+      // it to retrieve the transactions count
+      await this.fetchHTRTransactionCount();
+
       this.setState({
         loading: false,
       });
@@ -141,7 +145,6 @@ class TokenBalances extends React.Component {
       loading: false,
       page: 1,
       tokenBalances: tokenBalances.hits,
-      transactionsCount: tokenBalanceInformation.transactions,
       addressesCount: tokenBalanceInformation.addresses,
       hasAfter: tokenBalances.has_next,
       hasBefore: false,
@@ -226,6 +229,15 @@ class TokenBalances extends React.Component {
     });
   }
 
+  fetchHTRTransactionCount = async () => {
+    const tokenApiRequest = await tokensApi.getToken('00');
+
+    this.setState({
+      tokensApiError: get(tokenApiRequest, 'error', false),
+      transactionsCount: get(tokenApiRequest, 'data.hits[0].transactions', 0),
+    });
+  }
+
   onTokenSelected = async (token) => {
     if (!token) {
       await helpers.setStateAsync(this, {
@@ -234,7 +246,7 @@ class TokenBalances extends React.Component {
 
       // HTR token is the default, so the search API is not called, we must forcefully call it 
       // so we can retrieve the transactions count information
-
+      await this.fetchHTRTransactionCount();
 
       this.performSearch();
       return;
@@ -265,7 +277,7 @@ class TokenBalances extends React.Component {
 
   /**
    * Turn loading false.
-   * Useful to be used by autocomplete component when the first search doesn't find any token
+  * Useful to be used by autocomplete component when the first search doesn't find any token
    */
   loadingFinished = () => {
     this.setState({ loading: false });
@@ -319,7 +331,9 @@ class TokenBalances extends React.Component {
             !this.state.tokenBalanceInformationError && (
               <>
                 <p><b>Total number of addresses:</b> { helpers.renderValue(this.state.addressesCount, true) }</p>
-                <p><b>Total number of transactions:</b> { helpers.renderValue(this.state.transactionsCount, true) }</p>
+                {!this.state.tokensApiError && (
+                  <p><b>Total number of transactions:</b> { helpers.renderValue(this.state.transactionsCount, true) }</p>
+                )}
               </>
             )
           }

--- a/src/components/token/TokenBalances.js
+++ b/src/components/token/TokenBalances.js
@@ -232,6 +232,10 @@ class TokenBalances extends React.Component {
         tokenId: hathorLibConstants.HATHOR_TOKEN_CONFIG.uid
       });
 
+      // HTR token is the default, so the search API is not called, we must forcefully call it 
+      // so we can retrieve the transactions count information
+
+
       this.performSearch();
       return;
     }

--- a/src/components/token/TokenBalances.js
+++ b/src/components/token/TokenBalances.js
@@ -63,6 +63,7 @@ class TokenBalances extends React.Component {
      *                  our feature toggle service (Unleash) to remove additional load until the team fixes the problem
      * transactionsCount: Number of transactions for the searched token
      * addressesCount: Number of addressed for the searched token
+     * tokensApiError: Flag indicating if the request to the token api failed, to decide wether to display or not the total number of transactions
      */
     this.state = {
       tokenId,
@@ -81,6 +82,7 @@ class TokenBalances extends React.Component {
       maintenanceMode: this.props.maintenanceMode,
       transactionsCount: 0,
       addressesCount: 0,
+      tokensApiError: false,
     };
   }
 
@@ -254,6 +256,8 @@ class TokenBalances extends React.Component {
 
     await helpers.setStateAsync(this, {
       tokenId: token.id,
+      transactionsCount: token.transactions,
+      tokensApiError: false,
     });
 
     this.performSearch();


### PR DESCRIPTION
### Acceptance Criteria
- We should use the new fetch token API from the explorer-service to retrieve the hathor token transactions count
- We should use the `transactions` column from the token entry retrieved from the search to display the total number of transactions for a given token
- If the fetch token API request fails, we should hide the information


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
