### PR TITLE
fix: page NaN on querystring changes

### DIFF
--- a/src/components/AddressDetailExplorer.js
+++ b/src/components/AddressDetailExplorer.js
@@ -107,7 +107,7 @@ class AddressDetailExplorer extends React.Component {
       // update the query params state then fetch the new page
       this.setState({ queryParams, loadingHistory: true }, () => {
         // Fetch new data, unless query params were cleared and we were already in the most recent page
-        this.getHistoryData(+queryParams.page);
+        this.getHistoryData(+queryParams.page || 1);
       });
     }
   }

--- a/src/components/AddressHistory.js
+++ b/src/components/AddressHistory.js
@@ -84,7 +84,7 @@ class AddressHistory extends React.Component {
         return null;
       } else {
         const queryParams = this.props.pagination.obtainQueryParams();
-        const page = +queryParams.page;
+        const page = +queryParams.page || 1;
         const lastPage = Math.ceil(this.props.numTransactions / TX_COUNT);
         const pages = getPages(page, lastPage);
 


### PR DESCRIPTION
### Motivation

When searching for another address, sometimes the page is not set on the querystring and `+query.page` which would convert the page to a number returns `NaN`.
This makes a couple methods which expect a number to fail and not load the page properly.

### Acceptance Criteria
- Use the default page 1 when the querystring parameter `page` is not set.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
