### PR TITLE
feat(feature-activation): implement blocks page

### DIFF
--- a/src/api/featureApi.js
+++ b/src/api/featureApi.js
@@ -15,6 +15,13 @@ const featureApi = {
     });
   },
 
+  async getSignalBits(block) {
+    return requestExplorerServiceV1.get(`node_api/feature`, { params: { block } }).then(res => {
+      return res.data.signal_bits
+    });
+  }
+  
+
 };
 
 export default featureApi;

--- a/src/api/featureApi.js
+++ b/src/api/featureApi.js
@@ -9,15 +9,15 @@ import requestExplorerServiceV1 from './axiosInstance';
 
 const featureApi = {
 
-  async getFeatures() {
-    return requestExplorerServiceV1.get(`node_api/feature`).then(res => {
+  async getFeatures(block = null) {
+    return requestExplorerServiceV1.get(`node_api/feature`, { params: { block } }).then(res => {
       return res.data
     });
   },
 
   async getSignalBits(block) {
-    return requestExplorerServiceV1.get(`node_api/feature`, { params: { block } }).then(res => {
-      return res.data.signal_bits
+    return this.getFeatures(block).then(data => {
+      return data.signal_bits
     });
   }
   

--- a/src/components/feature_activation/FeatureDataRow.js
+++ b/src/components/feature_activation/FeatureDataRow.js
@@ -9,9 +9,9 @@ import React from 'react';
 import featureActivation from '../../utils/featureActivation';
 
 
-class SignalBitRow extends React.Component {
+class FeatureDataRow extends React.Component {
   render() {
-    const { bit, signal, feature, feature_state } = this.props.signalBit
+    const { bit, signal, feature, feature_state } = this.props.featureData
     const prettyState = featureActivation.getPrettyState(feature_state)
     const prettySignal = signal === 1 ? '✓' : ''
 
@@ -26,4 +26,4 @@ class SignalBitRow extends React.Component {
   }
 }
 
-export default SignalBitRow;
+export default FeatureDataRow;

--- a/src/components/feature_activation/FeatureRow.js
+++ b/src/components/feature_activation/FeatureRow.js
@@ -6,26 +6,14 @@
  */
 
 import React from 'react';
+import featureActivation from '../../utils/featureActivation';
 
 
 class FeatureRow extends React.Component {
-  getPrettyState(state) {
-    const prettyStates = {
-      DEFINED: 'Defined',
-      STARTED: 'Started',
-      MUST_SIGNAL: 'Must Signal',
-      LOCKED_IN: 'Locked-in',
-      ACTIVE: 'Active',
-      FAILED: 'Failed',
-    };
-
-    return prettyStates[state] || state;
-  }
-
   render() {
     const { acceptance, state } = this.props.feature
     const acceptance_percentage = acceptance === null ? '-' : `${(acceptance * 100).toFixed(0)}%`
-    const prettyState = this.getPrettyState(state)
+    const prettyState = featureActivation.getPrettyState(state)
 
     return (
       <tr>

--- a/src/components/feature_activation/SignalBitRow.js
+++ b/src/components/feature_activation/SignalBitRow.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import featureActivation from '../../utils/featureActivation';
+
+
+class SignalBitRow extends React.Component {
+  render() {
+    const { bit, signal, feature, feature_state } = this.props.signalBit
+    const prettyState = featureActivation.getPrettyState(feature_state)
+    const prettySignal = signal === 1 ? '✓' : ''
+
+    return (
+      <tr>
+        <td className="d-lg-table-cell pr-3">{bit}</td>
+        <td className="d-lg-table-cell pr-3">{prettySignal}</td>
+        <td className="d-lg-table-cell pr-3">{feature || '—'}</td>
+        <td className="d-lg-table-cell pr-3">{prettyState || '—'}</td>
+      </tr>
+    );
+  }
+}
+
+export default SignalBitRow;

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -144,7 +144,7 @@ class TxData extends React.Component {
     this.setState({ showFeatureActivation: !this.state.showFeatureActivation });
 
     if (!this.state.loadedSignalBits) {
-      const signalBits = await featureApi.getSignalBits(this.props.transaction.hash)
+      const signalBits = await featureApi.getSignalBits(this.props.transaction.hash) || []
       this.setState({ signalBits, loadedSignalBits: true })
     }
   }
@@ -619,6 +619,9 @@ class TxData extends React.Component {
     }
 
     const renderBitSignalTable = () => {
+      if (this.state.signalBits.length === 0) {
+        return (<div>There are currently no features.</div>)
+      }
       return (
         <div className="table-responsive mt-5">
           <table className="table table-striped" id="features-table">

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -22,7 +22,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { Link } from 'react-router-dom'
 import { Module, render } from 'viz.js/full.render.js';
 import Loading from '../Loading';
-import SignalBitRow from '../feature_activation/SignalBitRow';
+import FeatureDataRow from '../feature_activation/FeatureDataRow';
 import featureApi from '../../api/featureApi';
 
 /**
@@ -639,9 +639,9 @@ class TxData extends React.Component {
     }
 
     const renderBitSignalTableBody = () => {
-      return this.state.signalBits.map((signalBit) => {
+      return this.state.signalBits.map((featureData) => {
         return (
-          <SignalBitRow key={signalBit.bit} signalBit={signalBit} />
+          <FeatureDataRow key={featureData.bit} featureData={featureData} />
         );
       });
     }

--- a/src/utils/featureActivation.js
+++ b/src/utils/featureActivation.js
@@ -1,0 +1,16 @@
+const featureActivation = {
+  getPrettyState(state) {
+    const prettyStates = {
+      DEFINED: 'Defined',
+      STARTED: 'Started',
+      MUST_SIGNAL: 'Must Signal',
+      LOCKED_IN: 'Locked-in',
+      ACTIVE: 'Active',
+      FAILED: 'Failed',
+    };
+
+    return prettyStates[state] || state;
+  }
+}
+
+export default featureActivation


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-explorer/pull/242

### Acceptance Criteria

- Move `getPrettyState()` to utils file
- Implement the new signal bits table in the Block page as described in the [RFC](https://github.com/HathorNetwork/rfcs/blob/master/projects/feature-activation/0003-explorer-uis.md)

Here's an image of the new implemented block page:

![Screenshot 2023-07-31 at 19 49 54](https://github.com/HathorNetwork/hathor-explorer/assets/1757957/c88a08cb-b5bb-444d-a53a-e7e0938c2638)

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
