### PR TITLE
fix: nc arguments might be null or an empty array, so we must handle it properly

### DIFF
--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -637,6 +637,10 @@ class TxData extends React.Component {
     }
 
     const renderNCArguments = (args) => {
+      if (!args || !args.length) {
+        return " - ";
+      }
+
       return args.map((arg) => (
         <div key={arg.name}>
           <label>{arg.name}:</label> {renderArgValue(arg)}

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -638,7 +638,7 @@ class TxData extends React.Component {
 
     const renderNCArguments = (args) => {
       if (!Array.isArray(args) || args.length === 0) {
-        return " - ";
+        return ' - ';
       }
 
       return args.map((arg) => (

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -637,7 +637,7 @@ class TxData extends React.Component {
     }
 
     const renderNCArguments = (args) => {
-      if (!args || !args.length) {
+      if (!Array.isArray(args) || args.length === 0) {
         return " - ";
       }
 


### PR DESCRIPTION
### Motivation

A beta tester was testing a blueprint that has a method without arguments. A transaction with this method was throwing an error in the frontend because the arguments were `null`. I also improved the UI for an empty list.

### Acceptance Criteria
- We should show a single dash (-) when a nano contract transaction has no arguments in the Transaction Detail screen.

![image](https://github.com/HathorNetwork/hathor-explorer/assets/3298774/17e0a924-bb5b-44f6-b6c7-25eaefec8287)


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
