### PR TITLE
feat: hide tokens tab

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -12,6 +12,7 @@ import HathorAlert from './HathorAlert';
 import Version from './Version';
 import hathorLib from '@hathor/wallet-lib';
 import ConditionalNavigation from './ConditionalNavigation';
+import { useFlag } from '@unleash/proxy-client-react';
 import {
   UNLEASH_TOKENS_BASE_FEATURE_FLAG,
   UNLEASH_TOKEN_BALANCES_FEATURE_FLAG,
@@ -56,6 +57,11 @@ class Navigation extends React.Component {
     this.refs.alertError.show(3000);
   }
 
+  showTokensTab() {
+    return useFlag(`${UNLEASH_TOKENS_BASE_FEATURE_FLAG}.rollout`)
+      || useFlag(`${UNLEASH_TOKEN_BALANCES_FEATURE_FLAG}.rollout`);
+  }
+
   render() {
     return (
       <div className="main-nav">
@@ -73,17 +79,19 @@ class Navigation extends React.Component {
               <li className="nav-item">
                 <NavLink to="/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>Transactions</NavLink>
               </li>
-              <li className="nav-item dropdown">
-                <span className="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Tokens
-                </span>
-                <div className="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <ul>
-                    <ConditionalNavigation to="/tokens" label="Token list" featureToggle={`${UNLEASH_TOKENS_BASE_FEATURE_FLAG}.rollout`} />
-                    <ConditionalNavigation to="/token_balances" label="Token balances" featureToggle={`${UNLEASH_TOKEN_BALANCES_FEATURE_FLAG}.rollout`} />
-                  </ul>
-                </div>
-              </li>
+              {this.showTokensTab() && (
+                <li className="nav-item dropdown">
+                  <span className="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Tokens
+                  </span>
+                  <div className="dropdown-menu" aria-labelledby="navbarDropdown">
+                    <ul>
+                      <ConditionalNavigation to="/tokens" label="Token list" featureToggle={`${UNLEASH_TOKENS_BASE_FEATURE_FLAG}.rollout`} />
+                      <ConditionalNavigation to="/token_balances" label="Token balances" featureToggle={`${UNLEASH_TOKEN_BALANCES_FEATURE_FLAG}.rollout`} />
+                    </ul>
+                  </div>
+                </li>
+              )}
               <li className="nav-item">
                 <NavLink to="/network" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>Network</NavLink>
               </li>


### PR DESCRIPTION
### Acceptance Criteria

- Only show tokens tab if at least one of its options are enabled

### Motivation

All items under the tokens tab are protected behind an unleash feature flag, but if all feature flags are disabled the UI would show an empty dropdown

![image](https://github.com/HathorNetwork/hathor-explorer/assets/15909384/1aeb6d6b-ed02-4cc7-87e0-1d0b82ff7ac7)

To prevent this, we need to remove the tokens tab altogether when all feature flags are disabled.

For reference, when all items are enabled we have this:

![image](https://github.com/HathorNetwork/hathor-explorer/assets/15909384/3de2dc88-c1b7-442d-be3a-73ac16aea13f)

### Alternatives

Ideally we should have a component to conditionally render the tab, but using unleash's `useFlag` on callbacks and not on the component body directly would fail building the explorer.

Later we can refactor this with a custom hook to check multiple flags, but since this is the only instance where this behavior is required we can use conditional rendering without any code repetition.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
