### PR TITLE
ci: deploy to sub-accounts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [master, ci/deploy-to-sub-accounts]
+    branches: [master]
     tags: ['v*']
 
 permissions:
@@ -109,7 +109,7 @@ jobs:
           CLOUDFRONT_ID: EN58551BWE3XZ
 
   deploy-ekvilibro-testnet-explorer:
-    if: github.ref == 'refs/heads/ci/deploy-to-sub-accounts'
+    if: github.ref == 'refs/heads/master'
     needs: dependencies
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [master]
     tags: ['v*']
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   dependencies:
     runs-on: ubuntu-latest
@@ -53,7 +57,12 @@ jobs:
     steps:
       # https://github.com/actions/checkout/releases/tag/v4.1.7
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-
+      - name: Configure AWS Credentials
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.2
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRole
       - name: Download node modules
         # https://github.com/actions/download-artifact/releases/tag/v4.1.8
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -69,10 +78,63 @@ jobs:
         run: |
           make testnet_deploy
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: 'us-east-1'
           CLOUDFRONT_ID: E2TGO5SVP34CC3
+
+  deploy-nano-testnet-explorer:
+    if: github.ref == 'refs/heads/master'
+    needs: dependencies
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Configure AWS Credentials
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.2
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          aws-region: eu-central-1
+          role-to-assume: arn:aws:iam::471112952246:role/ExplorerGitHubActionsRole
+      - name: Download node modules
+        # https://github.com/actions/download-artifact/releases/tag/v3.0.2
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: node_modules
+      - name: Build
+        run: |
+          tar -xf node_modules.tar
+          make nano_testnet_build
+      - name: Deploy Nano Testnet Explorer
+        run: |
+          make nano_testnet_deploy
+        env:
+          CLOUDFRONT_ID: EN58551BWE3XZ
+
+  deploy-ekvilibro-testnet-explorer:
+    if: github.ref == 'refs/heads/master'
+    needs: dependencies
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Configure AWS Credentials
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.2
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          aws-region: eu-central-1
+          role-to-assume: arn:aws:iam::730335348496:role/ExplorerGitHubActionsRole
+      - name: Download node modules
+        # https://github.com/actions/download-artifact/releases/tag/v3.0.2
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: node_modules
+      - name: Build
+        run: |
+          tar -xf node_modules.tar
+          make ekvilibro_testnet_build
+      - name: Deploy Ekvilibro Testnet Explorer
+        run: |
+          make ekvilibro_testnet_deploy
+        env:
+          CLOUDFRONT_ID: E3SRP23QB7K3DQ
 
   deploy-mainnet-explorer:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -81,7 +143,12 @@ jobs:
     steps:
       # https://github.com/actions/checkout/releases/tag/v4.1.7
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-
+      - name: Configure AWS Credentials
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.2
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRole
       - name: Download node modules
         # https://github.com/actions/download-artifact/releases/tag/v4.1.8
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -97,7 +164,4 @@ jobs:
         run: |
           make mainnet_deploy
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: 'us-east-1'
           CLOUDFRONT_ID: ETOC9JKCK86OG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRole
+          role-to-assume: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRoleTestnet
       - name: Download node modules
         # https://github.com/actions/download-artifact/releases/tag/v4.1.8
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -120,7 +120,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           aws-region: eu-central-1
-          role-to-assume: arn:aws:iam::730335348496:role/ExplorerGitHubActionsRole
+          role-to-assume: arn:aws:iam::730335348496:role/ExplorerGitHubActionsRoleEkvilibroTestnet
       - name: Download node modules
         # https://github.com/actions/download-artifact/releases/tag/v3.0.2
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -147,7 +147,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           aws-region: eu-central-1
-          role-to-assume: arn:aws:iam::730335348496:role/ExplorerGitHubActionsRole
+          role-to-assume: arn:aws:iam::730335348496:role/ExplorerGitHubActionsRoleEkvilibroMainnet
       - name: Download node modules
         # https://github.com/actions/download-artifact/releases/tag/v3.0.2
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -174,7 +174,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRole
+          role-to-assume: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRoleMainnet
       - name: Download node modules
         # https://github.com/actions/download-artifact/releases/tag/v4.1.8
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,13 +72,11 @@ jobs:
       - name: Build
         run: |
           tar -xf node_modules.tar
-          make testnet_build
+          make build site=testnet
 
       - name: Deploy Testnet Explorer
         run: |
-          make testnet_deploy
-        env:
-          CLOUDFRONT_ID: E2TGO5SVP34CC3
+          make deploy site=testnet
 
   deploy-nano-testnet-explorer:
     if: github.ref == 'refs/heads/master'
@@ -101,12 +99,10 @@ jobs:
       - name: Build
         run: |
           tar -xf node_modules.tar
-          make nano_testnet_build
+          make build site=nano-testnet
       - name: Deploy Nano Testnet Explorer
         run: |
-          make nano_testnet_deploy
-        env:
-          CLOUDFRONT_ID: EN58551BWE3XZ
+          make deploy site=nano-testnet
 
   deploy-ekvilibro-testnet-explorer:
     if: github.ref == 'refs/heads/master'
@@ -129,12 +125,10 @@ jobs:
       - name: Build
         run: |
           tar -xf node_modules.tar
-          make ekvilibro_testnet_build
+          make build site=ekvilibro-testnet
       - name: Deploy Ekvilibro Testnet Explorer
         run: |
-          make ekvilibro_testnet_deploy
-        env:
-          CLOUDFRONT_ID: E3SRP23QB7K3DQ
+          make deploy site=ekvilibro-testnet
   deploy-ekvilibro-mainnet-explorer:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: dependencies
@@ -156,12 +150,10 @@ jobs:
       - name: Build
         run: |
           tar -xf node_modules.tar
-          make ekvilibro_mainnet_build
+          make build site=ekvilibro-mainnet
       - name: Deploy Ekvilibro Mainnet Explorer
         run: |
-          make ekvilibro_mainnet_deploy
-        env:
-          CLOUDFRONT_ID: E1NI147Y237J4M
+          make deploy site=ekvilibro-mainnet
   deploy-mainnet-explorer:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: dependencies
@@ -184,10 +176,8 @@ jobs:
       - name: Build
         run: |
           tar -xf node_modules.tar
-          make mainnet_build
+          make build site=mainnet
 
       - name: Deploy Mainnet Explorer
         run: |
-          make mainnet_deploy
-        env:
-          CLOUDFRONT_ID: ETOC9JKCK86OG
+          make deploy site=mainnet

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [master]
+    branches: [master, ci/deploy-to-sub-accounts]
     tags: ['v*']
 
 permissions:
@@ -109,7 +109,7 @@ jobs:
           CLOUDFRONT_ID: EN58551BWE3XZ
 
   deploy-ekvilibro-testnet-explorer:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/ci/deploy-to-sub-accounts'
     needs: dependencies
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [master, ci/deploy-to-sub-accounts]
+    branches: [master]
     tags: ['v*']
 
 permissions:
@@ -136,7 +136,7 @@ jobs:
         env:
           CLOUDFRONT_ID: E3SRP23QB7K3DQ
   deploy-ekvilibro-mainnet-explorer:
-    if: github.ref == 'refs/heads/ci/deploy-to-sub-accounts'
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: dependencies
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [master]
+    branches: [master, ci/deploy-to-sub-accounts]
     tags: ['v*']
 
 permissions:
@@ -135,7 +135,33 @@ jobs:
           make ekvilibro_testnet_deploy
         env:
           CLOUDFRONT_ID: E3SRP23QB7K3DQ
-
+  deploy-ekvilibro-mainnet-explorer:
+    if: github.ref == 'refs/heads/ci/deploy-to-sub-accounts'
+    needs: dependencies
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Configure AWS Credentials
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.2
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          aws-region: eu-central-1
+          role-to-assume: arn:aws:iam::730335348496:role/ExplorerGitHubActionsRole
+      - name: Download node modules
+        # https://github.com/actions/download-artifact/releases/tag/v3.0.2
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: node_modules
+      - name: Build
+        run: |
+          tar -xf node_modules.tar
+          make ekvilibro_mainnet_build
+      - name: Deploy Ekvilibro Mainnet Explorer
+        run: |
+          make ekvilibro_mainnet_deploy
+        env:
+          CLOUDFRONT_ID: E1NI147Y237J4M
   deploy-mainnet-explorer:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: dependencies

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -30,4 +30,4 @@ jobs:
 
       - name: Build
         run: |
-          make testnet_build
+          make build site=testnet

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,23 @@ ekvilibro_testnet_s3_sync:
 .PHONY: ekvilibro_testnet_deploy
 ekvilibro_testnet_deploy: check_version ekvilibro_testnet_s3_sync clear_cloudfront_cache
 
+.PHONY: ekvilibro_mainnet_build
+ekvilibro_mainnet_build:
+	FULLNODE_HOST=node-side-dag.ekvilibro-mainnet.hathor.network; \
+	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
+	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
+	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.ekvilibro-mainnet.hathor.network/; \
+	export REACT_APP_TIMESERIES_DASHBOARD_ID=; \
+	export REACT_APP_NETWORK=ekvilibro-mainnet; \
+	npm run build
+
+.PHONY: ekvilibro_mainnet_s3_sync
+ekvilibro_mainnet_s3_sync:
+	aws s3 sync --delete ./build/ s3://hathor-ekvilibro-mainnet-public-explorer
+
+.PHONY: ekvilibro_mainnet_deploy
+ekvilibro_mainnet_deploy: check_version ekvilibro_mainnet_s3_sync clear_cloudfront_cache
+
 .PHONY: testnet_build
 testnet_build:
 	FULLNODE_HOST=node.explorer.testnet.hathor.network; \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ nano_testnet_build:
 
 .PHONY: nano_testnet_s3_sync
 nano_testnet_s3_sync:
-	aws s3 sync --delete ./build/ s3://hathor-nano-testnet-public-explorer-2 --profile nano-testnet
+	aws s3 sync --delete ./build/ s3://hathor-nano-testnet-public-explorer-2
 
 .PHONY: nano_testnet_deploy
 nano_testnet_deploy: check_version nano_testnet_s3_sync clear_cloudfront_cache
@@ -35,7 +35,7 @@ ekvilibro_testnet_build:
 
 .PHONY: ekvilibro_testnet_s3_sync
 ekvilibro_testnet_s3_sync:
-	aws s3 sync --delete ./build/ s3://hathor-ekvilibro-testnet-public-explorer --profile ekvilibro
+	aws s3 sync --delete ./build/ s3://hathor-ekvilibro-testnet-public-explorer
 
 .PHONY: ekvilibro_testnet_deploy
 ekvilibro_testnet_deploy: check_version ekvilibro_testnet_s3_sync clear_cloudfront_cache

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+.PHONY: build
+build:
+	./scripts/deploy.sh $(site) build
+
+.PHONY: sync
+sync:
+	./scripts/deploy.sh $(site) sync
+
+.PHONY: deploy
+deploy: check_version sync clear_cloudfront_cache
+
 .PHONY: check_version
 check_version:
 	./scripts/check_version
@@ -6,112 +17,14 @@ check_version:
 check_tag:
 	./scripts/check_tag
 
-.PHONY: nano_testnet_build
-nano_testnet_build:
-	FULLNODE_HOST=node1.nano-testnet.hathor.network; \
-	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
-	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
-	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.nano-testnet.hathor.network/; \
-	export REACT_APP_TIMESERIES_DASHBOARD_ID=59683ac0-237a-11ef-8f75-578bca86e218; \
-	export REACT_APP_NETWORK=nano-testnet-alpha; \
-	npm run build
-
-.PHONY: nano_testnet_s3_sync
-nano_testnet_s3_sync:
-	aws s3 sync --delete ./build/ s3://hathor-nano-testnet-public-explorer-2
-
-.PHONY: nano_testnet_deploy
-nano_testnet_deploy: check_version nano_testnet_s3_sync clear_cloudfront_cache
-
-.PHONY: ekvilibro_testnet_build
-ekvilibro_testnet_build:
-	FULLNODE_HOST=node-side-dag.ekvilibro-testnet.hathor.network; \
-	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
-	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
-	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.ekvilibro-testnet.hathor.network/; \
-	export REACT_APP_TIMESERIES_DASHBOARD_ID=; \
-	export REACT_APP_NETWORK=ekvilibro-testnet; \
-	npm run build
-
-.PHONY: ekvilibro_testnet_s3_sync
-ekvilibro_testnet_s3_sync:
-	aws s3 sync --delete ./build/ s3://hathor-ekvilibro-testnet-public-explorer
-
-.PHONY: ekvilibro_testnet_deploy
-ekvilibro_testnet_deploy: check_version ekvilibro_testnet_s3_sync clear_cloudfront_cache
-
-.PHONY: ekvilibro_mainnet_build
-ekvilibro_mainnet_build:
-	FULLNODE_HOST=node-side-dag.ekvilibro-mainnet.hathor.network; \
-	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
-	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
-	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.ekvilibro-mainnet.hathor.network/; \
-	export REACT_APP_TIMESERIES_DASHBOARD_ID=; \
-	export REACT_APP_NETWORK=ekvilibro-mainnet; \
-	npm run build
-
-.PHONY: ekvilibro_mainnet_s3_sync
-ekvilibro_mainnet_s3_sync:
-	aws s3 sync --delete ./build/ s3://hathor-ekvilibro-mainnet-public-explorer
-
-.PHONY: ekvilibro_mainnet_deploy
-ekvilibro_mainnet_deploy: check_version ekvilibro_mainnet_s3_sync clear_cloudfront_cache
-
-.PHONY: testnet_build
-testnet_build:
-	FULLNODE_HOST=node.explorer.testnet.hathor.network; \
-	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
-	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
-	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.testnet.hathor.network/; \
-	export REACT_APP_TIMESERIES_DASHBOARD_ID=35379840-e8c5-11ec-a7f2-0fee9be0d8ee; \
-	export REACT_APP_NETWORK=testnet; \
-	npm run build
-
-.PHONY: testnet_s3_sync
-testnet_s3_sync:
-	aws s3 sync --delete ./build/ s3://hathor-testnet-golf-public-explorer
-
-.PHONY: testnet_deploy
-testnet_deploy: check_version testnet_s3_sync clear_cloudfront_cache
-
-.PHONY: mainnet_build
-mainnet_build:
-	FULLNODE_HOST=node.explorer.hathor.network; \
-	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
-	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
-	export REACT_APP_GTM_ID=GTM-MJVX6BG; \
-	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.hathor.network/; \
-	export REACT_APP_TIMESERIES_DASHBOARD_ID=674ebc10-e8c4-11ec-a7f2-0fee9be0d8ee; \
-	export REACT_APP_NETWORK=mainnet; \
-	npm run build
-
-.PHONY: mainnet_s3_sync
-mainnet_s3_sync:
-	aws s3 sync --delete ./build/ s3://hathor-mainnet-public-explorer
-
-.PHONY: mainnet_deploy
-mainnet_deploy: check_version check_tag mainnet_s3_sync clear_cloudfront_cache
-
 .PHONY: clear_cloudfront_cache
 clear_cloudfront_cache:
-	aws cloudfront create-invalidation --distribution-id $$CLOUDFRONT_ID --paths "/index.html"
+	./scripts/deploy.sh $(site) clear_cache
 
 .PHONY: testnet_local
 testnet_local:
-	FULLNODE_HOST=node.explorer.testnet.hathor.network; \
-	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
-	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
-	export REACT_APP_EXPLORER_SERVICE_BASE_URL=http://localhost:3001/dev/; \
-	export REACT_APP_TIMESERIES_DASHBOARD_ID=35379840-e8c5-11ec-a7f2-0fee9be0d8ee; \
-	export REACT_APP_NETWORK=testnet; \
-	npm run start
+	./scripts/deploy.sh testnet-local start
 
 .PHONY: mainnet_local
 mainnet_local:
-	FULLNODE_HOST=node.explorer.hathor.network; \
-	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
-	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
-	export REACT_APP_EXPLORER_SERVICE_BASE_URL=http://localhost:3001/dev/; \
-	export REACT_APP_TIMESERIES_DASHBOARD_ID=674ebc10-e8c4-11ec-a7f2-0fee9be0d8ee; \
-	export REACT_APP_NETWORK=mainnet; \
-	npm run start
+	./scripts/deploy.sh mainnet-local start

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,40 @@ check_version:
 check_tag:
 	./scripts/check_tag
 
+.PHONY: nano_testnet_build
+nano_testnet_build:
+	FULLNODE_HOST=node1.nano-testnet.hathor.network; \
+	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
+	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
+	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.nano-testnet.hathor.network/; \
+	export REACT_APP_TIMESERIES_DASHBOARD_ID=59683ac0-237a-11ef-8f75-578bca86e218; \
+	export REACT_APP_NETWORK=nano-testnet-alpha; \
+	npm run build
+
+.PHONY: nano_testnet_s3_sync
+nano_testnet_s3_sync:
+	aws s3 sync --delete ./build/ s3://hathor-nano-testnet-public-explorer-2 --profile nano-testnet
+
+.PHONY: nano_testnet_deploy
+nano_testnet_deploy: check_version nano_testnet_s3_sync clear_cloudfront_cache
+
+.PHONY: ekvilibro_testnet_build
+ekvilibro_testnet_build:
+	FULLNODE_HOST=node-side-dag.ekvilibro-testnet.hathor.network; \
+	export REACT_APP_BASE_URL=https://$$FULLNODE_HOST/v1a/; \
+	export REACT_APP_WS_URL=wss://$$FULLNODE_HOST/v1a/ws/; \
+	export REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.ekvilibro-testnet.hathor.network/; \
+	export REACT_APP_TIMESERIES_DASHBOARD_ID=; \
+	export REACT_APP_NETWORK=ekvilibro-testnet; \
+	npm run build
+
+.PHONY: ekvilibro_testnet_s3_sync
+ekvilibro_testnet_s3_sync:
+	aws s3 sync --delete ./build/ s3://hathor-ekvilibro-testnet-public-explorer --profile ekvilibro
+
+.PHONY: ekvilibro_testnet_deploy
+ekvilibro_testnet_deploy: check_version ekvilibro_testnet_s3_sync clear_cloudfront_cache
+
 .PHONY: testnet_build
 testnet_build:
 	FULLNODE_HOST=node.explorer.testnet.hathor.network; \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -102,7 +102,7 @@ case $command in
     echo "REACT_APP_TIMESERIES_DASHBOARD_ID: $REACT_APP_TIMESERIES_DASHBOARD_ID"
     echo "REACT_APP_NETWORK: $REACT_APP_NETWORK"
     # Run the build command
-    # npm run build
+    npm run build
     ;;
   sync)
     echo "Syncing for site: $site"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# Check if site and command parameters are provided
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <site> <command>"
+  exit 1
+fi
+
+site=$1
+command=$2
+
+# Define environment variables for each site
+case $site in
+  mainnet-local)
+    FULLNODE_HOST=node.explorer.hathor.network
+    REACT_APP_BASE_URL=http://$FULLNODE_HOST/v1a/
+    REACT_APP_WS_URL=ws://$FULLNODE_HOST/v1a/ws/
+    REACT_APP_EXPLORER_SERVICE_BASE_URL=http://localhost:3001/dev/
+    REACT_APP_TIMESERIES_DASHBOARD_ID=674ebc10-e8c4-11ec-a7f2-0fee9be0d8ee
+    REACT_APP_NETWORK=mainnet
+    ;;
+  testnet-local)
+    FULLNODE_HOST=node.explorer.testnet.hathor.network
+    REACT_APP_BASE_URL=http://$FULLNODE_HOST/v1a/
+    REACT_APP_WS_URL=ws://$FULLNODE_HOST/v1a/ws/
+    REACT_APP_EXPLORER_SERVICE_BASE_URL=http://localhost:3001/dev/
+    REACT_APP_TIMESERIES_DASHBOARD_ID=35379840-e8c5-11ec-a7f2-0fee9be0d8ee
+    REACT_APP_NETWORK=testnet
+    ;;
+  nano-testnet)
+    FULLNODE_HOST=node1.nano-testnet.hathor.network
+    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
+    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
+    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.nano-testnet.hathor.network/
+    REACT_APP_TIMESERIES_DASHBOARD_ID=59683ac0-237a-11ef-8f75-578bca86e218
+    REACT_APP_NETWORK=nano-testnet-alpha
+    S3_BUCKET=hathor-nano-testnet-public-explorer-2
+    CLOUDFRONT_ID=EN58551BWE3XZ
+    ;;
+  ekvilibro-testnet)
+    FULLNODE_HOST=node-side-dag.ekvilibro-testnet.hathor.network
+    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
+    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
+    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.ekvilibro-testnet.hathor.network/
+    REACT_APP_TIMESERIES_DASHBOARD_ID=
+    REACT_APP_NETWORK=ekvilibro-testnet
+    S3_BUCKET=hathor-ekvilibro-testnet-public-explorer
+    CLOUDFRONT_ID=E3SRP23QB7K3DQ
+    ;;
+  ekvilibro-mainnet)
+    FULLNODE_HOST=node-side-dag.ekvilibro-mainnet.hathor.network
+    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
+    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
+    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.ekvilibro-mainnet.hathor.network/
+    REACT_APP_TIMESERIES_DASHBOARD_ID=
+    REACT_APP_NETWORK=ekvilibro-mainnet
+    S3_BUCKET=hathor-ekvilibro-mainnet-public-explorer
+    CLOUDFRONT_ID=E1NI147Y237J4M
+    ;;
+  testnet)
+    FULLNODE_HOST=node.explorer.testnet.hathor.network
+    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
+    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
+    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.testnet.hathor.network/
+    REACT_APP_TIMESERIES_DASHBOARD_ID=35379840-e8c5-11ec-a7f2-0fee9be0d8ee
+    REACT_APP_NETWORK=testnet
+    S3_BUCKET=hathor-testnet-golf-public-explorer
+    CLOUDFRONT_ID=E2TGO5SVP34CC3
+    ;;
+  mainnet)
+    FULLNODE_HOST=node.explorer.hathor.network
+    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
+    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
+    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.mainnet.hathor.network/
+    REACT_APP_TIMESERIES_DASHBOARD_ID=674ebc10-e8c4-11ec-a7f2-0fee9be0d8ee
+    REACT_APP_NETWORK=mainnet
+    S3_BUCKET=hathor-mainnet-public-explorer
+    CLOUDFRONT_ID=ETOC9JKCK86OG
+    ;;
+  *)
+    echo "Unknown site: $site"
+    exit 1
+    ;;
+esac
+
+export FULLNODE_HOST
+export REACT_APP_BASE_URL
+export REACT_APP_WS_URL
+export REACT_APP_EXPLORER_SERVICE_BASE_URL
+export REACT_APP_TIMESERIES_DASHBOARD_ID
+export REACT_APP_NETWORK
+export S3_BUCKET
+export CLOUDFRONT_ID
+
+case $command in
+  build)
+    echo "Building for site: $site"
+    echo "FULLNODE_HOST: $FULLNODE_HOST"
+    echo "REACT_APP_BASE_URL: $REACT_APP_BASE_URL"
+    echo "REACT_APP_WS_URL: $REACT_APP_WS_URL"
+    echo "REACT_APP_EXPLORER_SERVICE_BASE_URL: $REACT_APP_EXPLORER_SERVICE_BASE_URL"
+    echo "REACT_APP_TIMESERIES_DASHBOARD_ID: $REACT_APP_TIMESERIES_DASHBOARD_ID"
+    echo "REACT_APP_NETWORK: $REACT_APP_NETWORK"
+    # Run the build command
+    # npm run build
+    ;;
+  sync)
+    echo "Syncing for site: $site"
+    aws s3 sync --delete ./build/ s3://$S3_BUCKET
+    ;;
+  clear_cache)
+    echo "Clearing CloudFront cache for site: $site"
+	aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/index.html"
+    ;;
+  start)
+    echo "Starting for site: $site"
+    npm run start
+    ;;
+  *)
+    echo "Unknown command: $command"
+    exit 1
+    ;;
+esac

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -110,7 +110,7 @@ case $command in
     ;;
   clear_cache)
     echo "Clearing CloudFront cache for site: $site"
-	aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/index.html"
+    aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/index.html"
     ;;
   start)
     echo "Starting for site: $site"


### PR DESCRIPTION
### Acceptance Criteria
- Use https://github.com/aws-actions/configure-aws-credentials to get temporary AWS Credentials for the job, instead of using permanent credentials stored in Github. The roles that will be assumed by Github Actions for this are being created in https://github.com/HathorNetwork/ops-tools/pull/871
- Add steps to deploy to our alternative testnets every time we deploy to the main one
- Refactor the Makefile so it uses a bash script for the deploy logic

### TODO

- [ ] Remove old user used for deploys

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
