### PR TITLE
chore: NodeJS 20 on package and workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,16 +9,18 @@ jobs:
   dependencies:
     runs-on: ubuntu-latest
     steps:
-      # https://github.com/actions/checkout/releases/tag/v3.5.3
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      - name: Set up Node.js 18.x
-        # https://github.com/actions/setup-node/releases/tag/v3.7.0
-        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
+      # https://github.com/actions/checkout/releases/tag/v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Set up Node.js 20.x
+        # https://github.com/actions/setup-node/releases/tag/v4.0.3
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
-          node-version: 18.x
+          node-version: 20.x
+
       - name: Cache node modules
-        # https://github.com/actions/cache/releases/tag/v3.3.1
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        # https://github.com/actions/cache/releases/tag/v4.0.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         env:
           cache-name: cache-node-modules
         with:
@@ -29,33 +31,40 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
       - name: Install Dependencies
         run: |
           npm install
           tar -cvf node_modules.tar ./node_modules
+
       - name: Upload node modules
-        uses: actions/upload-artifact@v2
+        # https://github.com/actions/upload-artifact/releases/tag/v4.3.4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
         with:
           name: node_modules
           path: node_modules.tar
           if-no-files-found: error
           retention-days: 1
+
   deploy-testnet-explorer:
     if: github.ref == 'refs/heads/master'
     needs: dependencies
     runs-on: ubuntu-latest
     steps:
-      # https://github.com/actions/checkout/releases/tag/v3.5.3
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+      # https://github.com/actions/checkout/releases/tag/v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
       - name: Download node modules
-        # https://github.com/actions/download-artifact/releases/tag/v3.0.2
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        # https://github.com/actions/download-artifact/releases/tag/v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: node_modules
+
       - name: Build
         run: |
           tar -xf node_modules.tar
           make testnet_build
+
       - name: Deploy Testnet Explorer
         run: |
           make testnet_deploy
@@ -64,22 +73,26 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: 'us-east-1'
           CLOUDFRONT_ID: E2TGO5SVP34CC3
+
   deploy-mainnet-explorer:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: dependencies
     runs-on: ubuntu-latest
     steps:
-      # https://github.com/actions/checkout/releases/tag/v3.5.3
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+      # https://github.com/actions/checkout/releases/tag/v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
       - name: Download node modules
-        # https://github.com/actions/download-artifact/releases/tag/v3.0.2
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        # https://github.com/actions/download-artifact/releases/tag/v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: node_modules
+
       - name: Build
         run: |
           tar -xf node_modules.tar
           make mainnet_build
+
       - name: Deploy Mainnet Explorer
         run: |
           make mainnet_deploy

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,18 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
     steps:
-      # https://github.com/actions/checkout/releases/tag/v3.5.3
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+      # https://github.com/actions/checkout/releases/tag/v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
       - name: Use Node.js ${{ matrix.node-version }}
-        # https://github.com/actions/setup-node/releases/tag/v3.7.0
-        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
+        # https://github.com/actions/setup-node/releases/tag/v4.0.3
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
           node-version: ${{ matrix.node-version }}
+
       - name: Install Dependencies
         run: |
           npm install
+
       - name: Build
         run: |
           make testnet_build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "hathor-admin",
   "version": "0.19.1",
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  },
   "private": true,
   "dependencies": {
     "@hathor/wallet-lib": "1.8.0",


### PR DESCRIPTION
### Acceptance Criteria
- The `package.json` must restrict the Node.js version to `20`
- The workflows must use this same version for running the Explorer application
- The third-party workflow actions used must also run on Node.js `20`

### Notes
The actions related to _Artifacts_ had [breaking changes](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/) from `v3` to `v4`. We expect to have no impact with our current usage since we're upgrading both the `upload` and `download` actions at the same time, and so they remain compatible within the workflow.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
