### PR TITLE
feat: add blueprint code to the blueprint detail screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "d3-selection": "3.0.0",
         "d3-zoom": "3.0.0",
         "font-awesome": "4.7.0",
+        "highlight.js": "^11.10.0",
         "jquery": "3.7.1",
         "lodash": "4.17.21",
         "npm-run-all": "4.1.5",
@@ -11880,6 +11881,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "node_modules/highlight.js": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.10.0.tgz",
+      "integrity": "sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/history": {
       "version": "4.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "d3-selection": "3.0.0",
         "d3-zoom": "3.0.0",
         "font-awesome": "4.7.0",
-        "highlight.js": "^11.10.0",
+        "highlight.js": "11.10.0",
         "jquery": "3.7.1",
         "lodash": "4.17.21",
         "npm-run-all": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "d3-selection": "3.0.0",
     "d3-zoom": "3.0.0",
     "font-awesome": "4.7.0",
-    "highlight.js": "^11.10.0",
+    "highlight.js": "11.10.0",
     "jquery": "3.7.1",
     "lodash": "4.17.21",
     "npm-run-all": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "d3-selection": "3.0.0",
     "d3-zoom": "3.0.0",
     "font-awesome": "4.7.0",
+    "highlight.js": "^11.10.0",
     "jquery": "3.7.1",
     "lodash": "4.17.21",
     "npm-run-all": "4.1.5",

--- a/src/api/nanoApi.js
+++ b/src/api/nanoApi.js
@@ -77,11 +77,14 @@ const nanoApi = {
    */
   getBlueprintSourceCode(blueprintId) {
     const data = { blueprint_id: blueprintId };
-    return requestExplorerServiceV1.get(`node_api/nc_blueprint_source_code`, {params: data}).then((res) => {
-      return res.data
-    }, (res) => {
-      throw new Error(res.data.message);
-    });
+    return requestExplorerServiceV1.get(`node_api/nc_blueprint_source_code`, { params: data }).then(
+      res => {
+        return res.data;
+      },
+      res => {
+        throw new Error(res.data.message);
+      }
+    );
   },
 };
 

--- a/src/api/nanoApi.js
+++ b/src/api/nanoApi.js
@@ -67,6 +67,22 @@ const nanoApi = {
       }
     );
   },
+
+  /**
+   * Get the blueprint source code
+   *
+   * @param {string} blueprintId ID of the blueprint
+   *
+   * For more details, see full node api docs
+   */
+  getBlueprintSourceCode(blueprintId) {
+    const data = { blueprint_id: blueprintId };
+    return requestExplorerServiceV1.get(`node_api/nc_blueprint_source_code`, {params: data}).then((res) => {
+      return res.data
+    }, (res) => {
+      throw new Error(res.data.message);
+    });
+  },
 };
 
 export default nanoApi;

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import App from './App';
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'font-awesome/css/font-awesome.min.css';
+import 'highlight.js/styles/github.css';
 import './index.css';
 
 import store from './store/index';

--- a/src/index.scss
+++ b/src/index.scss
@@ -631,6 +631,23 @@ th.sortable {
   background-color: transparent !important;
 }
 
-.source-code {
+.source-code code {
   background-color: #f2f2f2;
+}
+
+.source-code pre {
+  height: 100%;
+}
+
+.source-code {
+  -webkit-transition: all 1s ease;
+  -moz-transition: all 1s ease;
+  transition: all 1s ease;
+  height: 0;
+  opacity: 0;
+}
+
+.source-code.show {
+  height: auto !important;
+  opacity: 1 !important;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -630,3 +630,7 @@ th.sortable {
 .table-method-arguments tbody tr {
   background-color: transparent !important;
 }
+
+.source-code {
+  background-color: #f2f2f2;
+}

--- a/src/screens/nano/BlueprintDetail.js
+++ b/src/screens/nano/BlueprintDetail.js
@@ -6,10 +6,10 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-import Loading from '../../components/Loading';
-import nanoApi from '../../api/nanoApi';
 import hljs from 'highlight.js/lib/core';
 import python from 'highlight.js/lib/languages/python';
+import Loading from '../../components/Loading';
+import nanoApi from '../../api/nanoApi';
 
 hljs.registerLanguage('python', python);
 
@@ -41,14 +41,14 @@ function BlueprintDetail(props) {
       setLoading(true);
       setBlueprintInformation(null);
       try {
-        const blueprintInformation = await nanoApi.getBlueprintInformation(blueprintId);
-        const blueprintSourceCode = await nanoApi.getBlueprintSourceCode(blueprintId);
+        const blueprintInformationData = await nanoApi.getBlueprintInformation(blueprintId);
+        const blueprintSourceCodeData = await nanoApi.getBlueprintSourceCode(blueprintId);
         if (ignore) {
           // This is to prevent setting a state after the component has been already cleaned
           return;
         }
-        setBlueprintInformation(blueprintInformation);
-        setBlueprintSourceCode(blueprintSourceCode.source_code);
+        setBlueprintInformation(blueprintInformationData);
+        setBlueprintSourceCode(blueprintSourceCodeData.source_code);
       } catch (e) {
         if (ignore) {
           // This is to prevent setting a state after the component has been already cleaned
@@ -142,10 +142,10 @@ function BlueprintDetail(props) {
    *
    * @param {Event} e Click event
    */
-  const onToggleShowCode = (e) => {
+  const onToggleShowCode = e => {
     e.preventDefault();
     setShowCode(!showCode);
-  }
+  };
 
   return (
     <div className="content-wrapper">
@@ -160,16 +160,20 @@ function BlueprintDetail(props) {
           {blueprintInformation.name}
         </p>
         <h4 className="mt-5 mb-4">Attributes</h4>
-        { renderBlueprintAttributes() }
-        { renderBlueprintMethods('public_methods', 'Public Methods') }
-        { renderBlueprintMethods('private_methods', 'Private Methods') }
+        {renderBlueprintAttributes()}
+        {renderBlueprintMethods('public_methods', 'Public Methods')}
+        {renderBlueprintMethods('private_methods', 'Private Methods')}
         <div className="d-flex flex-row align-items-center mb-4 mt-4">
           <h4 className="mb-0 mr-3">Source Code</h4>
-          <a href="true" onClick={(e) => onToggleShowCode(e)}>{showCode ? 'Hide' : 'Show'}</a>
+          <a href="true" onClick={e => onToggleShowCode(e)}>
+            {showCode ? 'Hide' : 'Show'}
+          </a>
         </div>
         <div className={`source-code ${showCode ? 'show' : ''}`}>
           <pre>
-            <code ref={codeRef} className='language-python'>{blueprintSourceCode}</code>
+            <code ref={codeRef} className="language-python">
+              {blueprintSourceCode}
+            </code>
           </pre>
         </div>
       </div>

--- a/src/screens/nano/BlueprintDetail.js
+++ b/src/screens/nano/BlueprintDetail.js
@@ -29,6 +29,8 @@ function BlueprintDetail(props) {
   const [loading, setLoading] = useState(true);
   // errorMessage {string | null} Error message in case a request to get nano contract data fails
   const [errorMessage, setErrorMessage] = useState(null);
+  // showCode {boolean} If should show the blueprint source code
+  const [showCode, setShowCode] = useState(false);
 
   const codeRef = useRef();
 
@@ -135,6 +137,16 @@ function BlueprintDetail(props) {
     return `${name}(${parameters.join(', ')}): ${returnType === 'null' ? 'None' : returnType}`;
   };
 
+  /**
+   * Handle toggle click to hide or show the blueprint source code
+   *
+   * @param {Event} e Click event
+   */
+  const onToggleShowCode = (e) => {
+    e.preventDefault();
+    setShowCode(!showCode);
+  }
+
   return (
     <div className="content-wrapper">
       <h3 className="mt-4">Blueprint Information</h3>
@@ -151,8 +163,15 @@ function BlueprintDetail(props) {
         { renderBlueprintAttributes() }
         { renderBlueprintMethods('public_methods', 'Public Methods') }
         { renderBlueprintMethods('private_methods', 'Private Methods') }
-        <h4 className="mt-5 mb-4">Source Code</h4>
-        <pre><code ref={codeRef} className='source-code language-python'>{blueprintSourceCode}</code></pre>
+        <div className="d-flex flex-row align-items-center mb-4 mt-4">
+          <h4 className="mb-0 mr-3">Source Code</h4>
+          <a href="true" onClick={(e) => onToggleShowCode(e)}>{showCode ? 'Hide' : 'Show'}</a>
+        </div>
+        <div className={`source-code ${showCode ? 'show' : ''}`}>
+          <pre>
+            <code ref={codeRef} className='language-python'>{blueprintSourceCode}</code>
+          </pre>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Acceptance Criteria
- We must show the blueprint source code in the blueprint detail screen.

Note I: I decided to install a package to highlight the code because the UI is improved a lot, the package is extensively used, and the explorer is not a code as critical as the wallet in terms of handling sensitive data.

Note II: it needs a new API in the nano hathor core (https://github.com/HathorNetwork/nano-hathor-core/pull/96) and the corresponding API in the explorer service (https://github.com/HathorNetwork/hathor-explorer-service/pull/333)

https://github.com/user-attachments/assets/77dbd9af-08da-4fea-990e-b94f0c719e2a

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
