### PR TITLE
fix: Websocket linting and error warning

### DIFF
--- a/src/WebSocketHandler.js
+++ b/src/WebSocketHandler.js
@@ -47,8 +47,11 @@ class WS extends EventEmitter {
     this.heartbeat = setInterval(this.sendPing, HEARTBEAT_TMO);
   }
 
-  onClose() {
+  onClose(evt) {
     this.connected = false;
+    if (evt?.code === 1006) {
+      console.warn('Abnormal ws connection closure. Are you using a secure ws connection?');
+    }
     setTimeout(this.setup, 5000);
     clearInterval(this.heartbeat);
     console.log('ws connection closed');


### PR DESCRIPTION
### Acceptance Criteria
- Fixes linting issues on the websocket file that were causing `Parse errors` on the arrow functions
- Adds a warning to help identify if the `ws://` protocol is being incorrectly used instead of `wss://`, which is helpful after the changes on #274 


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
