### PR TITLE
fix: upgrade download-artifact action version to fix error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,8 +92,8 @@ jobs:
           aws-region: eu-central-1
           role-to-assume: arn:aws:iam::471112952246:role/ExplorerGitHubActionsRole
       - name: Download node modules
-        # https://github.com/actions/download-artifact/releases/tag/v3.0.2
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        # https://github.com/actions/download-artifact/releases/tag/v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: node_modules
       - name: Build
@@ -118,8 +118,8 @@ jobs:
           aws-region: eu-central-1
           role-to-assume: arn:aws:iam::730335348496:role/ExplorerGitHubActionsRoleEkvilibroTestnet
       - name: Download node modules
-        # https://github.com/actions/download-artifact/releases/tag/v3.0.2
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        # https://github.com/actions/download-artifact/releases/tag/v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: node_modules
       - name: Build
@@ -143,8 +143,8 @@ jobs:
           aws-region: eu-central-1
           role-to-assume: arn:aws:iam::730335348496:role/ExplorerGitHubActionsRoleEkvilibroMainnet
       - name: Download node modules
-        # https://github.com/actions/download-artifact/releases/tag/v3.0.2
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        # https://github.com/actions/download-artifact/releases/tag/v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: node_modules
       - name: Build


### PR DESCRIPTION
### Acceptance Criteria
- We should stop getting the error we had in https://github.com/HathorNetwork/hathor-explorer/actions/runs/10619060179/job/29435812404

This is another one I triggered with the fix showing that it could go past the steps that was erroring: https://github.com/HathorNetwork/hathor-explorer/actions/runs/10619740019/job/29438015637


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
