### PR TITLE
fix: Default error handling on api helpers

### DIFF
--- a/src/api/addressApiLegacy.js
+++ b/src/api/addressApiLegacy.js
@@ -17,8 +17,8 @@ const addressApi = {
         }
         return undefined;
       })
-      .catch(_error => {
-        // something wrong with request
+      .catch(error => {
+        console.error(`Failure obtaining address ${address} balance`, error);
       });
   },
 
@@ -49,8 +49,8 @@ const addressApi = {
         }
         return undefined;
       })
-      .catch(_error => {
-        // something wrong with request
+      .catch(error => {
+        console.error('Failure searching for addresses', error);
       });
   },
 };

--- a/src/api/graphvizApi.js
+++ b/src/api/graphvizApi.js
@@ -16,7 +16,9 @@ const graphvizApi = {
         return res.data;
       },
       res => {
-        throw new Error(res.data.message);
+        throw new Error(
+          res?.data?.message || res?.message || 'Unknown error at get node neighbors'
+        );
       }
     );
   },

--- a/src/api/metadataApi.js
+++ b/src/api/metadataApi.js
@@ -17,8 +17,8 @@ const metadataApi = {
         }
         return undefined;
       })
-      .catch(_error => {
-        // something wrong with request
+      .catch(error => {
+        console.error(`Error fetching dag metadata for ${id}`, error);
       });
   },
 };

--- a/src/api/nanoApi.js
+++ b/src/api/nanoApi.js
@@ -20,14 +20,16 @@ const nanoApi = {
    */
   getState(id, fields, balances, calls) {
     const data = { id, fields, balances, calls };
-    return requestExplorerServiceV1.get(`node_api/nc_state`, { params: data }).then(
-      res => {
+    return requestExplorerServiceV1
+      .get(`node_api/nc_state`, { params: data })
+      .then(res => {
         return res.data;
-      },
-      res => {
-        throw new Error(res.data.message);
-      }
-    );
+      })
+      .catch(err => {
+        throw new Error(
+          err?.data?.message || err?.message || `Unknown error on get nc state for ${id}`
+        );
+      });
   },
 
   /**
@@ -51,14 +53,12 @@ const nanoApi = {
     if (before) {
       data.before = before;
     }
-    return requestExplorerServiceV1.get(`node_api/nc_history`, { params: data }).then(
-      res => {
-        return res.data;
-      },
-      res => {
-        throw new Error(res.data.message);
-      }
-    );
+    return requestExplorerServiceV1
+      .get(`node_api/nc_history`, { params: data })
+      .then(res => res.data)
+      .catch(err => {
+        throw new Error(err?.data?.message || err?.message || `Unknown error on get nc history`);
+      });
   },
 
   /**
@@ -70,14 +70,16 @@ const nanoApi = {
    */
   getBlueprintInformation(blueprintId) {
     const data = { blueprint_id: blueprintId };
-    return requestExplorerServiceV1.get(`node_api/nc_blueprint_information`, { params: data }).then(
-      res => {
-        return res.data;
-      },
-      res => {
-        throw new Error(res.data.message);
-      }
-    );
+    return requestExplorerServiceV1
+      .get(`node_api/nc_blueprint_information`, { params: data })
+      .then(res => res.data)
+      .catch(err => {
+        throw new Error(
+          err?.data?.message ||
+            err?.message ||
+            `Unknown error on get blueprint data for ${blueprintId}`
+        );
+      });
   },
 
   /**
@@ -89,14 +91,16 @@ const nanoApi = {
    */
   getBlueprintSourceCode(blueprintId) {
     const data = { blueprint_id: blueprintId };
-    return requestExplorerServiceV1.get(`node_api/nc_blueprint_source_code`, { params: data }).then(
-      res => {
-        return res.data;
-      },
-      res => {
-        throw new Error(res.data.message);
-      }
-    );
+    return requestExplorerServiceV1
+      .get(`node_api/nc_blueprint_source_code`, { params: data })
+      .then(res => res.data)
+      .catch(err => {
+        throw new Error(
+          err?.data?.message ||
+            err?.message ||
+            `Unknown error on get blueprint source code for ${blueprintId}`
+        );
+      });
   },
 };
 

--- a/src/api/nanoApi.js
+++ b/src/api/nanoApi.js
@@ -22,9 +22,7 @@ const nanoApi = {
     const data = { id, fields, balances, calls };
     return requestExplorerServiceV1
       .get(`node_api/nc_state`, { params: data })
-      .then(res => {
-        return res.data;
-      })
+      .then(res => res.data)
       .catch(err => {
         throw new Error(
           err?.data?.message || err?.message || `Unknown error on get nc state for ${id}`

--- a/src/api/networkApi.js
+++ b/src/api/networkApi.js
@@ -12,13 +12,13 @@ const networkApi = {
     return requestExplorerServiceV1
       .get(`node`)
       .then(res => {
-        if (!res.data) {
+        if (!res?.data) {
           throw new Error('unknown_error');
         }
         return res.data;
       })
       .catch(res => {
-        throw new Error(res.data.message);
+        throw new Error(res?.data?.message || res?.message || 'Unknown error on get all nodes');
       });
   },
   getPeer(hash) {
@@ -31,7 +31,7 @@ const networkApi = {
         return res.data;
       })
       .catch(res => {
-        throw new Error(res.data.message);
+        throw new Error(res?.data?.message || res?.message || `Unknown error on get node ${hash}`);
       });
   },
 };

--- a/src/api/tokenApi.js
+++ b/src/api/tokenApi.js
@@ -10,38 +10,36 @@ import { TX_COUNT } from '../constants';
 
 const tokenApi = {
   getList() {
-    return requestExplorerServiceV1.get(`node_api/tokens`).then(
-      res => {
-        return res.data;
-      },
-      res => {
-        throw new Error(res.data.message);
-      }
-    );
+    return requestExplorerServiceV1
+      .get(`node_api/tokens`)
+      .then(res => res.data)
+      .catch(err => {
+        throw new Error(err?.data?.message || err?.message || `Unknown error on get tokens list`);
+      });
   },
 
   get(id) {
     const data = { id };
-    return requestExplorerServiceV1.get(`node_api/token`, { params: data }).then(
-      res => {
-        return res.data;
-      },
-      res => {
-        throw new Error(res.data.message);
-      }
-    );
+    return requestExplorerServiceV1
+      .get(`node_api/token`, { params: data })
+      .then(res => res.data)
+      .catch(err => {
+        throw new Error(
+          err?.data?.message || err?.message || `Unknown error on get token data for ${id}`
+        );
+      });
   },
 
   getHistory(id, timestamp, hash, page) {
     const data = { id, timestamp, hash, page, count: TX_COUNT };
-    return requestExplorerServiceV1.get(`node_api/token_history`, { params: data }).then(
-      res => {
-        return res.data;
-      },
-      res => {
-        throw new Error(res.data.message);
-      }
-    );
+    return requestExplorerServiceV1
+      .get(`node_api/token_history`, { params: data })
+      .then(res => res.data)
+      .catch(err => {
+        throw new Error(
+          err?.data?.message || err?.message || `Unknown error on get history for ${id}`
+        );
+      });
   },
 };
 

--- a/src/api/txApi.js
+++ b/src/api/txApi.js
@@ -91,14 +91,9 @@ const txApi = {
    */
   getConfirmationData(id) {
     const data = { id };
-    return requestExplorerServiceV1.get(`node_api/transaction_acc_weight`, { params: data }).then(
-      res => {
-        return res.data;
-      },
-      res => {
-        return Promise.reject(res);
-      }
-    );
+    return requestExplorerServiceV1
+      .get(`node_api/transaction_acc_weight`, { params: data })
+      .then(res => res.data);
   },
 };
 

--- a/src/api/version.js
+++ b/src/api/version.js
@@ -9,14 +9,12 @@ import requestExplorerServiceV1 from './axiosInstance';
 
 const versionApi = {
   getVersion() {
-    return requestExplorerServiceV1.get(`node_api/version`).then(
-      res => {
-        return res.data;
-      },
-      res => {
-        throw new Error(res.data.message);
-      }
-    );
+    return requestExplorerServiceV1
+      .get(`node_api/version`)
+      .then(res => res.data)
+      .catch(err => {
+        throw new Error(err?.data?.message || err?.message || `Unknown error on get node version`);
+      });
   },
 };
 


### PR DESCRIPTION
### Acceptance Criteria
- The default error handlers for our APIs should also handle errors not related to Axios
- Handlers that were expected to only output to console should do so


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
