### PR TITLE
refactor: AddressDetailExplorer to fn component

### DIFF
--- a/src/components/AddressDetailExplorer.js
+++ b/src/components/AddressDetailExplorer.js
@@ -210,22 +210,19 @@ function AddressDetailExplorer() {
    * Will discard any errors and always set the metadataLoaded to true, even without any data.
    * @type {(function(*): Promise<void>)|*}
    */
-  const getSelectedTokenMetadata = useCallback(
-    async tokenToFetch => {
-      if (tokenToFetch === hathorLib.constants.NATIVE_TOKEN_UID) {
-        console.warn(`getSelectedTokenMetadata setting metadata loaded`);
-        setMetadataLoaded(true);
-        return;
-      }
-
-      const dagData = await metadataApi.getDagMetadata(tokenToFetch);
-      if (dagData) {
-        setSelectedTokenMetadata(dagData);
-      }
+  const getSelectedTokenMetadata = useCallback(async tokenToFetch => {
+    if (tokenToFetch === hathorLib.constants.NATIVE_TOKEN_UID) {
+      console.warn(`getSelectedTokenMetadata setting metadata loaded`);
       setMetadataLoaded(true);
-    },
-    [metadataLoaded]
-  );
+      return;
+    }
+
+    const dagData = await metadataApi.getDagMetadata(tokenToFetch);
+    if (dagData) {
+      setSelectedTokenMetadata(dagData);
+    }
+    setMetadataLoaded(true);
+  }, []);
 
   const reloadTokenSummaryAndHistory = useCallback(
     async (addressToReload, tokenToReload) => {

--- a/src/components/AddressDetailExplorer.js
+++ b/src/components/AddressDetailExplorer.js
@@ -37,10 +37,14 @@ function shouldUpdate(tx, checkToken, queryToken, updateAddress) {
   const arr = [...tx.outputs, ...tx.inputs];
 
   for (const element of arr) {
-    if (element.decoded.address === updateAddress) {
-      // Address is the same
-      if ((checkToken && element.token === queryToken) || !checkToken) {
-        // Need to check token and token is the same, or no need to check token
+    if (element?.decoded?.address === updateAddress) {
+      // Address is the same, and this is enough to require update
+      if (!checkToken) {
+        return true;
+      }
+
+      // Need to check token and token is the same
+      if (element.token === queryToken) {
         return true;
       }
     }

--- a/src/components/AddressDetailExplorer.js
+++ b/src/components/AddressDetailExplorer.js
@@ -199,12 +199,14 @@ function AddressDetailExplorer() {
       }
 
       Promise.all(txPromises).then(txResults => {
-        const newCache = { ...txCache };
-        for (const txData of txResults) {
-          const tx = { ...txData.tx, meta: txData.meta };
-          newCache[tx.hash] = tx;
-        }
-        setTxCache(newCache);
+        setTxCache(oldCache => {
+          const newCache = { ...oldCache };
+          for (const txData of txResults) {
+            const tx = { ...txData.tx, meta: txData.meta };
+            newCache[tx.hash] = tx;
+          }
+          return newCache;
+        });
       });
       setLoadingHistory(false);
 


### PR DESCRIPTION
### Acceptance Criteria
- Refactors the AddressDetailExplorer to functional component

### Motivation
This component used the deprecated [`withRouter` connector](https://v5.reactrouter.com/web/api/withRouter), which will become unavailable in the coming upgrade to React Router v6.

In order to remove its usage, it was necessary to refactor it to use react hooks as a functional component. This proved to be harder than initially foreseen because the code relied heavily upon async state setters, a feature that is also no longer available with `useState()` hooks.

So, instead of setting the state, waiting for it to be rendered and then applying the next set of instructions, the code now sets the state and then a `useEffect()` handles its change. Many data flow reorganizations were made to achieve this new structure.

### Note for the reviewers
Since this component is so complex and had deep changes to its data flow, I'd recommend checking the [before](https://github.com/HathorNetwork/hathor-explorer/blob/b61769d6a6395dbc5c96f5f3c2a462107b693048/src/components/AddressDetailExplorer.js) and [after](https://github.com/HathorNetwork/hathor-explorer/blob/f35fc80fe5aca7b6b4866076081d02567702d8c8/src/components/AddressDetailExplorer.js) versions of the code to understand the changes made.


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
