### PR TITLE
Fix: Transaction detail metadata

### DIFF
--- a/src/screens/TransactionDetail.js
+++ b/src/screens/TransactionDetail.js
@@ -62,10 +62,10 @@ function TransactionDetail() {
       setConfirmationData(confirmationDataResponse);
     }
 
-    // Get transaction metadata from explorer service, overwriting the one already obtained
+    // Get transaction metadata from explorer service, adding to the transaction properties
     const metadataResponse = await metadataApi.getDagMetadata(id);
     if (metadataResponse) {
-      setMeta(metadataResponse);
+      setTransaction({ ...txData.tx, meta: metadataResponse });
     }
   }, []);
 


### PR DESCRIPTION
On #297 a bug was implemented that added the Transaction metadata into the wrong state property.  This PR fixes this mistake with the expected behavior of [the previous iteration](https://github.com/HathorNetwork/hathor-explorer/blob/b61769d6a6395dbc5c96f5f3c2a462107b693048/src/screens/TransactionDetail.js#L101) of this screen.

### Acceptance Criteria
- Correctly updates the transaction metadata with the response from the Explorer Service


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
