### PR TITLE
chore: use hathor play full node for nano testnet deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,7 +28,7 @@ case $site in
     REACT_APP_NETWORK=testnet
     ;;
   nano-testnet)
-    FULLNODE_HOST=node1.nano-testnet.hathor.network
+    FULLNODE_HOST=hathorplay.nano-testnet.hathor.network
     REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
     REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
     REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.nano-testnet.hathor.network/


### PR DESCRIPTION
### Acceptance Criteria

- Node 1 nano testnet is not up to date with the latest full node changes. We must use the hathorplay node for the nano testnet.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
