### PR TITLE
fix: Fix QA issues

### DIFF
--- a/src/components/Network.js
+++ b/src/components/Network.js
@@ -53,7 +53,7 @@ class Network extends React.Component {
 
   loadPeers() {
     const {
-      match: { params },
+      match: params,
     } = this.props;
 
     networkApi

--- a/src/components/tx/Transactions.js
+++ b/src/components/tx/Transactions.js
@@ -5,16 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import ReactLoading from 'react-loading';
-import { Link } from 'react-router-dom';
-import { isEqual } from 'lodash';
+import { Link, useLocation } from 'react-router-dom';
 import { TX_COUNT } from '../../constants';
 import TxRow from './TxRow';
 import helpers from '../../utils/helpers';
 import WebSocketHandler from '../../WebSocketHandler';
 import colors from '../../index.scss';
 import PaginationURL from '../../utils/pagination';
+import { reverse } from 'lodash';
 
 /**
  * Displays transactions history in a table with pagination buttons. As the user navigates through the history,
@@ -32,233 +32,273 @@ import PaginationURL from '../../utils/pagination';
  *   ts = "1579637190"
  *   page = "next"
  */
-class Transactions extends React.Component {
-  constructor(props) {
-    super(props);
+function Transactions({ shouldUpdateList, updateData, title }) {
+  // We must use memo here because we were creating a new pagination
+  // object in every new render, so the useEffect was being called forever
+  const pagination = useMemo(
+    () =>
+      new PaginationURL({
+        ts: { required: false },
+        hash: { required: false },
+        page: { required: false },
+      }),
+    []
+  );
 
-    this.pagination = new PaginationURL({
-      ts: { required: false },
-      hash: { required: false },
-      page: { required: false },
-    });
+  const location = useLocation();
 
-    this.state = {
-      transactions: [],
-      firstHash: null,
-      firstTimestamp: null,
-      lastHash: null,
-      lastTimestamp: null,
-      loaded: false,
-      hasAfter: false,
-      hasBefore: false,
-      queryParams: this.pagination.obtainQueryParams(),
-    };
-  }
+  // loaded {boolean} Bool to show/hide loading element
+  const [loaded, setLoaded] = useState(false);
+  // transactions {Array} Transaction history
+  const [transactions, setTransactions] = useState([]);
+  // hasBefore {boolean} If 'Previous' button should be enabled
+  const [hasBefore, setHasBefore] = useState(false);
+  // hasAfter {boolean} If 'Next' button should be enabled
+  const [hasAfter, setHasAfter] = useState(false);
+  // firstHash {string | null} First hash of the current list
+  const [firstHash, setFirstHash] = useState(null);
+  // firstTimestamp {number | null} First timestamp of the current list
+  const [firstTimestamp, setFirstTimestamp] = useState(null);
+  // lastHash {string | null} Last hash of the current list
+  const [lastHash, setLastHash] = useState(null);
+  // lastTimestamp {number | null} Last timestamp of the current list
+  const [lastTimestamp, setLastTimestamp] = useState(null);
 
-  componentDidMount() {
-    this.getData(this.state.queryParams);
-
-    WebSocketHandler.on('network', this.handleWebsocket);
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    const queryParams = this.pagination.obtainQueryParams();
-
-    // Do we have new URL params?
-    if (!isEqual(this.state.queryParams, queryParams)) {
-      // Fetch new data, unless query params were cleared and we were already in the most recent page
-      if (queryParams.hash || this.state.hasBefore) {
-        this.getData(queryParams);
-      }
-    }
-  }
-
-  componentWillUnmount() {
-    WebSocketHandler.removeListener('network', this.handleWebsocket);
-  }
-
-  handleWebsocket = wsData => {
-    if (wsData.type === 'network:new_tx_accepted') {
-      this.updateListWs(wsData);
-    }
-  };
-
-  updateListWs = tx => {
-    // We only add new tx/blocks if it's the first page
-    if (!this.state.hasBefore) {
-      if (this.props.shouldUpdateList(tx)) {
-        let transactions = this.state.transactions;
-        let hasAfter =
-          this.state.hasAfter || (transactions.length === TX_COUNT && !this.state.hasAfter);
-        transactions = helpers.updateListWs(transactions, tx, TX_COUNT);
-
-        let firstHash = transactions[0].tx_id;
-        let firstTimestamp = transactions[0].timestamp;
-        let lastHash = transactions[transactions.length - 1].tx_id;
-        let lastTimestamp = transactions[transactions.length - 1].timestamp;
-
-        // Finally we update the state again
-        this.setState({
-          transactions,
-          hasAfter,
-          firstHash,
-          lastHash,
-          firstTimestamp,
-          lastTimestamp,
-        });
-      }
-    }
-  };
-
-  handleDataFetched = (data, queryParams) => {
-    // Handle differently if is the first GET response we receive
-    // page indicates if was clicked 'previous' or 'next'
-    // Set first and last hash of the transactions
-    let firstHash = null;
-    let lastHash = null;
-    let firstTimestamp = null;
-    let lastTimestamp = null;
-    if (data.transactions.length) {
-      firstHash = data.transactions[0].tx_id;
-      lastHash = data.transactions[data.transactions.length - 1].tx_id;
-      firstTimestamp = data.transactions[0].timestamp;
-      lastTimestamp = data.transactions[data.transactions.length - 1].timestamp;
-    }
-
-    let hasAfter;
-    let hasBefore;
-    if (queryParams.page === 'previous') {
-      hasAfter = true;
-      hasBefore = data.has_more;
+  /**
+   * useCallback is important here to update this method with new history state
+   * otherwise it would be fixed the moment the event listener is started in the useEffect
+   * with the history as an empty array
+   *
+   * @param {Transaction} tx Transaction object that arrived from the websocket
+   */
+  const updateListWs = useCallback(
+    tx => {
+      // We only add new tx/blocks if it's the first page
       if (!hasBefore) {
-        // Went back to most recent page: clear URL params
-        this.pagination.clearOptionalQueryParams();
-      }
-    } else if (queryParams.page === 'next') {
-      hasBefore = true;
-      hasAfter = data.has_more;
-    } else {
-      // First load without parameters
-      hasBefore = false;
-      hasAfter = data.has_more;
-    }
+        if (shouldUpdateList(tx)) {
+          const newHasAfter = hasAfter || (transactions.length === TX_COUNT && !hasAfter);
+          const newTransactions = helpers.updateListWs(transactions, tx, TX_COUNT);
 
-    this.setState({
-      transactions: data.transactions,
-      loaded: true,
-      firstHash,
-      lastHash,
-      firstTimestamp,
-      lastTimestamp,
-      hasAfter,
-      hasBefore,
-      queryParams,
-    });
+          const newFirstHash = transactions[0].tx_id;
+          const newFirstTimestamp = transactions[0].timestamp;
+          const newLastHash = transactions[transactions.length - 1].tx_id;
+          const newLastTimestamp = transactions[transactions.length - 1].timestamp;
+
+          // Finally we update the state again
+          setTransactions(newTransactions);
+          setFirstHash(newFirstHash);
+          setFirstTimestamp(newFirstTimestamp);
+          setLastHash(newLastHash);
+          setLastTimestamp(newLastTimestamp);
+          setHasAfter(newHasAfter);
+        }
+      }
+    },
+    [transactions, hasAfter, hasBefore, shouldUpdateList]
+  );
+
+  /**
+   * useCallback is needed here because this method is used as a dependency in the useEffect
+   *
+   * Method to handle websocket messages that arrive in the network scope
+   * This method will discard any messages that are not new transactions
+   *
+   * wsData {Object} Data send in the websocket message
+   */
+  const handleWebsocket = useCallback(
+    wsData => {
+      if (wsData.type === 'network:new_tx_accepted') {
+        updateListWs(wsData);
+      }
+    },
+    [updateListWs]
+  );
+
+  /**
+   * useCallback is needed here because this method is used as a dependency in another useCallback
+   *
+   * Method to handle state updates after the new data is fetched
+   *
+   * data {Object} Data object from POST response with array of transactions (data.transactions)
+   * queryParams {Object} Query parameters of the URL
+   */
+  const handleDataFetched = useCallback(
+    (data, queryParams) => {
+      // Handle differently if is the first GET response we receive
+      // page indicates if was clicked 'previous' or 'next'
+      // Set first and last hash of the transactions
+
+      if (queryParams.page === 'previous') {
+        // When we are querying the previous set of transactions
+        // the API return the oldest first, so we need to revert the history
+        reverse(data.transactions);
+      }
+
+      let newFirstHash = null;
+      let newLastHash = null;
+      let newFirstTimestamp = null;
+      let newLastTimestamp = null;
+      if (data.transactions.length) {
+        newFirstHash = data.transactions[0].tx_id;
+        newLastHash = data.transactions[data.transactions.length - 1].tx_id;
+        newFirstTimestamp = data.transactions[0].timestamp;
+        newLastTimestamp = data.transactions[data.transactions.length - 1].timestamp;
+      }
+
+      let newHasAfter;
+      let newHasBefore;
+      if (queryParams.page === 'previous') {
+        newHasAfter = true;
+        newHasBefore = data.has_more;
+        if (!newHasBefore) {
+          // Went back to most recent page: clear URL params
+          pagination.clearOptionalQueryParams();
+        }
+      } else if (queryParams.page === 'next') {
+        newHasBefore = true;
+        newHasAfter = data.has_more;
+      } else {
+        // First load without parameters
+        newHasBefore = false;
+        newHasAfter = data.has_more;
+      }
+
+      setTransactions(data.transactions);
+      setFirstHash(newFirstHash);
+      setFirstTimestamp(newFirstTimestamp);
+      setLastHash(newLastHash);
+      setLastTimestamp(newLastTimestamp);
+      setHasAfter(newHasAfter);
+      setHasBefore(newHasBefore);
+      setLoaded(true);
+    },
+    [pagination]
+  );
+
+  /**
+   * useCallback is needed here because this method is used as a dependency in the useEffect
+   *
+   * Method used to call the props method that will fetch new data
+   * depending on the current query params
+   *
+   * queryParams {Object} Query parameters of the URL
+   */
+  const getData = useCallback(
+    queryParams => {
+      updateData(queryParams.ts, queryParams.hash, queryParams.page).then(
+        data => {
+          handleDataFetched(data, queryParams);
+        },
+        e => {
+          // Error in request
+          console.log(e);
+        }
+      );
+    },
+    [handleDataFetched, updateData]
+  );
+
+  useEffect(() => {
+    // Handle load history depending on the query params in the URL
+    getData(pagination.obtainQueryParams());
+  }, [location, getData, pagination]);
+
+  useEffect(() => {
+    // Handle new txs in the network to update the list in real time
+    WebSocketHandler.on('network', handleWebsocket);
+
+    return () => {
+      WebSocketHandler.removeListener('network', handleWebsocket);
+    };
+  }, [handleWebsocket]);
+
+  const loadPagination = () => {
+    if (transactions.length === 0) {
+      return null;
+    } else {
+      return (
+        <nav aria-label="Tx pagination" className="d-flex justify-content-center">
+          <ul className="pagination">
+            <li
+              className={
+                !hasBefore || transactions.length === 0
+                  ? 'page-item me-3 disabled'
+                  : 'page-item me-3'
+              }
+            >
+              <Link
+                className="page-link"
+                to={pagination.setURLParameters({
+                  ts: firstTimestamp,
+                  hash: firstHash,
+                  page: 'previous',
+                })}
+              >
+                Previous
+              </Link>
+            </li>
+            <li
+              className={
+                !hasAfter || transactions.length === 0
+                  ? 'page-item disabled'
+                  : 'page-item'
+              }
+            >
+              <Link
+                className="page-link"
+                to={pagination.setURLParameters({
+                  ts: lastTimestamp,
+                  hash: lastHash,
+                  page: 'next',
+                })}
+              >
+                Next
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      );
+    }
   };
 
-  getData(queryParams) {
-    this.props.updateData(queryParams.ts, queryParams.hash, queryParams.page).then(
-      data => {
-        this.handleDataFetched(data, queryParams);
-      },
-      e => {
-        // Error in request
-        console.log(e);
-      }
-    );
-  }
-
-  render() {
-    const loadPagination = () => {
-      if (this.state.transactions.length === 0) {
-        return null;
-      } else {
-        return (
-          <nav aria-label="Tx pagination" className="d-flex justify-content-center">
-            <ul className="pagination">
-              <li
-                ref="txPrevious"
-                className={
-                  !this.state.hasBefore || this.state.transactions.length === 0
-                    ? 'page-item me-3 disabled'
-                    : 'page-item me-3'
-                }
-              >
-                <Link
-                  className="page-link"
-                  to={this.pagination.setURLParameters({
-                    ts: this.state.firstTimestamp,
-                    hash: this.state.firstHash,
-                    page: 'previous',
-                  })}
-                >
-                  Previous
-                </Link>
-              </li>
-              <li
-                ref="txNext"
-                className={
-                  !this.state.hasAfter || this.state.transactions.length === 0
-                    ? 'page-item disabled'
-                    : 'page-item'
-                }
-              >
-                <Link
-                  className="page-link"
-                  to={this.pagination.setURLParameters({
-                    ts: this.state.lastTimestamp,
-                    hash: this.state.lastHash,
-                    page: 'next',
-                  })}
-                >
-                  Next
-                </Link>
-              </li>
-            </ul>
-          </nav>
-        );
-      }
-    };
-
-    const loadTable = () => {
-      return (
-        <div className="table-responsive mt-5">
-          <table className="table table-striped" id="tx-table">
-            <thead>
-              <tr>
-                <th className="d-none d-lg-table-cell">Hash</th>
-                <th className="d-none d-lg-table-cell">Timestamp</th>
-                <th className="d-table-cell d-lg-none" colSpan="2">
-                  Hash
-                  <br />
-                  Timestamp
-                </th>
-              </tr>
-            </thead>
-            <tbody>{loadTableBody()}</tbody>
-          </table>
-        </div>
-      );
-    };
-
-    const loadTableBody = () => {
-      return this.state.transactions.map((tx, idx) => {
-        return <TxRow key={tx.tx_id} tx={tx} />;
-      });
-    };
-
+  const loadTable = () => {
     return (
-      <div className="w-100">
-        {this.props.title}
-        {!this.state.loaded ? (
-          <ReactLoading type="spin" color={colors.purpleHathor} delay={500} />
-        ) : (
-          loadTable()
-        )}
-        {loadPagination()}
+      <div className="table-responsive mt-5">
+        <table className="table table-striped" id="tx-table">
+          <thead>
+            <tr>
+              <th className="d-none d-lg-table-cell">Hash</th>
+              <th className="d-none d-lg-table-cell">Timestamp</th>
+              <th className="d-table-cell d-lg-none" colSpan="2">
+                Hash
+                <br />
+                Timestamp
+              </th>
+            </tr>
+          </thead>
+          <tbody>{loadTableBody()}</tbody>
+        </table>
       </div>
     );
-  }
+  };
+
+  const loadTableBody = () => {
+    return transactions.map((tx, idx) => {
+      return <TxRow key={tx.tx_id} tx={tx} />;
+    });
+  };
+
+  return (
+    <div className="w-100">
+      {title}
+      {!loaded ? (
+        <ReactLoading type="spin" color={colors.purpleHathor} delay={500} />
+      ) : (
+        loadTable()
+      )}
+      {loadPagination()}
+    </div>
+  );
 }
 
 export default Transactions;

--- a/src/screens/TokenDetail.js
+++ b/src/screens/TokenDetail.js
@@ -79,11 +79,9 @@ function TokenDetail() {
     }
     setToken(oldToken => {
       return {
-        token: {
-          ...oldToken,
-          uid: id,
-          meta: data,
-        },
+        ...oldToken,
+        uid: id,
+        meta: data,
       };
     });
   };


### PR DESCRIPTION
### Context

After @tuliomir ran the QA, 3 issues were found. They are described [here](https://github.com/HathorNetwork/internal-issues/issues/390#issuecomment-2360848009).

1. The bug in the Transactions list affected all lists, and the cause was that the `componentDidUpdate` was not triggered when the query parameters changed. I decided to refactor the component to a functional component because this would be done in the future anyway, so I fixed the issue and did the refactor.
2. This issue affected all Token Detail screens of NFTs. The fix was simple (@tuliomir had already done it) and was just the correct way of setting the state.
3. This one was caused by a difference in the way we are passing the parameters data to the `Network` component right now. `this.props` had `match: { peerId: undefined }`, so I had to fix the destructuring, so it could correctly get the `peerId` information.

Note: While refactoring the `Transactions` component I found a bug that is affecting the mainnet-production explorer. When the user clicks the 'Previous' button in the list, the API returns the data in the reverse order, so we must reverse the data when this happens. In the middle of the refactor, I also fixed it.

### Acceptance Criteria
- Refactor `Transactions` component to a functional component fixing the bug when the update was not being triggered when the query params changed.
- Fix order of data when user clicked the 'Previous' button in lists that used the `Transactions` component.
- Fix Token Detail screen when the token is an NFT correctly setting the state of metadata.
- Fix Network screen correctly getting the `peerId` query param.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
