### PR TITLE
fix: show error message when decode tx fails

### DIFF
--- a/src/screens/DecodeTx.js
+++ b/src/screens/DecodeTx.js
@@ -45,14 +45,15 @@ function DecodeTx() {
   const buttonClicked = async () => {
     try {
       const data = await txApi.decodeTx(dataToDecode);
-      setSuccess(data.success);
       if (!data.success) {
         setTransaction(null);
         setConfirmationData(null);
         setMeta(null);
         setSpentOutputs(null);
+        setSuccess(false);
         return;
       }
+      setSuccess(true);
       setTransaction(data.tx);
       setMeta(data.meta);
       setSpentOutputs(data.spent_outputs);


### PR DESCRIPTION
### Context

https://github.com/HathorNetwork/hathor-explorer/issues/331

The decode-tx API does not return `success: False` when the decoding fails, that's why the current code has a bug.

### Acceptance Criteria
- The error message should be correctly shown when decoding an invalid tx.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
