### PR TITLE
bump: v0.20.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hathor-admin",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hathor-admin",
-      "version": "0.20.5",
+      "version": "0.20.6",
       "dependencies": {
         "@hathor/wallet-lib": "1.10.0",
         "@unleash/proxy-client-react": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-admin",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=10.0.0"

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,7 +57,7 @@ export const TESTNET_GENESIS_TX = [
   '00975897028ceb037307327c953f5e7ad4d3f42402d71bd3d11ecb63ac39f01a',
 ];
 
-export const VERSION = '0.20.5';
+export const VERSION = '0.20.6';
 
 export const MIN_API_VERSION = '0.33.0';
 


### PR DESCRIPTION
### Acceptance Criteria
- We're doing this bump directly to `master` because there has been an error in https://github.com/HathorNetwork/hathor-explorer/pull/337, which was merged to `master` instead of `dev`.
- We want to release only the commit that went directly to `master` this time, so it made sense to bump on it
- After this release, we will merge the `master` back into `dev` to make sure it gets the 2 commits (the change and the bump)


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
