### PR TITLE
refactor: centralize version number on package

### DIFF
--- a/scripts/check_version
+++ b/scripts/check_version
@@ -1,16 +1,26 @@
 #!/bin/bash
 
-SRC_VERSION=`grep "const VERSION " ./src/constants.js | cut -d"'" -f2`
+set -e  # Exit on any command failure.
+set -u  # Exit on unset variables.
+
 PACKAGE_VERSION=`grep '"version":' ./package.json | cut -d '"' -f4`
+PACKAGE_LOCK_VERSION=`node -p "require('./package-lock.json').version"`
+PACKAGE_LOCK_VERSION_2=`node -p "require('./package-lock.json').packages[''].version"`
 
 # For debugging:
-# echo x${SRC_VERSION}x
 # echo x${PACKAGE_VERSION}x
+# echo x${PACKAGE_LOCK_VERSION}x
+# echo x${PACKAGE_LOCK_VERSION_2}x
 
 EXITCODE=0
 
-if [[ x${PACKAGE_VERSION}x != x${SRC_VERSION}x ]]; then
-	echo Version different in package.json and src/constants.js
+if [[ x${PACKAGE_VERSION}x != x${PACKAGE_LOCK_VERSION}x ]]; then
+	echo Version different in package.json and package-lock.json
+	EXITCODE=-1
+fi
+
+if [[ x${PACKAGE_VERSION}x != x${PACKAGE_LOCK_VERSION_2}x ]]; then
+	echo Version different in package.json and the packages property in package-lock.json
 	EXITCODE=-1
 fi
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import { version } from '../package.json';
 
 export const BASE_URL =
   process.env.REACT_APP_BASE_URL || 'https://node.explorer.hathor.network/v1a/';
@@ -57,7 +58,7 @@ export const TESTNET_GENESIS_TX = [
   '00975897028ceb037307327c953f5e7ad4d3f42402d71bd3d11ecb63ac39f01a',
 ];
 
-export const VERSION = '0.20.6';
+export const VERSION = version;
 
 export const MIN_API_VERSION = '0.33.0';
 


### PR DESCRIPTION
### Acceptance Criteria
- All code paths that require the version number should fetch if from the `package.json` directly
- The `check_version` script should validate both application version numbers from the lockfile


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
