### PR TITLE
fix: Statistics seconds counter

### DIFF
--- a/src/newUi.scss
+++ b/src/newUi.scss
@@ -1477,6 +1477,18 @@ nav {
     padding: 4px 12px 4px 12px;
     border-radius: 4px;
   }
+
+  span.synced-at {
+    border: 0;
+    background-color: inherit;
+    margin: auto 0;
+    font-family: 'San Francisco Pro';
+    font-size: 10px;
+    font-weight: 500;
+    line-height: 18px;
+    letter-spacing: 0.03em;
+    text-align: left;
+  }
 }
 
 .real-time-info-container {
@@ -1511,17 +1523,6 @@ nav {
     line-height: 44px;
     text-align: left;
     color: var(--bold-text-color);
-  }
-
-  p {
-    margin: 0;
-    font-family: 'San Francisco Pro';
-    font-size: 10px;
-    font-weight: 500;
-    line-height: 18px;
-    letter-spacing: 0.03em;
-    text-align: left;
-    color: #57606a;
   }
 }
 

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -18,6 +18,12 @@ import useTimelapseCounter from '../hooks/useTimelapseCounter';
 function Dashboard() {
   const newUiEnabled = useNewUiEnabled();
   const [timestamp, setTimestamp] = useState(null);
+  /**
+   * Data from the last block received from the WS
+   * @property {number} transactions Number of transactions in the last block
+   * @property {number} best_block_height Best block height
+   * @property {number} hash_rate Hash rate
+   */
   const heightData = useSelector(state => state.data);
   const [summary, setSummary] = useState({
     transactions: 0,
@@ -41,13 +47,24 @@ function Dashboard() {
       return;
     }
 
-    setSummary({
-      bestBlockHeight: heightData.best_block_height,
-      transactions: heightData.transactions,
-      hashRate: heightData.hash_rate,
-    });
-    setTimestamp(new Date(heightData.time * 1000));
-  }, [heightData, summary.bestBlockHeight, summary.transactions]);
+    const newSummary = { ...summary };
+
+    // Handling the transactions number
+    if (heightData.transactions !== summary.transactions) {
+      newSummary.transactions = heightData.transactions;
+    }
+
+    // Handling the best block height, hash rate and sync timestamp
+    if (heightData.best_block_height !== summary.bestBlockHeight) {
+      newSummary.bestBlockHeight = heightData.best_block_height;
+      newSummary.hashRate = heightData.hash_rate;
+
+      // Setting the timestamp of when the last block was synced with this screen
+      setTimestamp(new Date(heightData.time * 1000));
+    }
+
+    setSummary(newSummary);
+  }, [heightData, summary]);
 
   if (heightData === null) {
     return (
@@ -90,22 +107,22 @@ function Dashboard() {
       <div className="statistics-title-container">
         <h2 className="statistics-title">Statistics</h2>
         <span>Real time</span>
+        <span className="real-time-info">
+          <p>LATEST BLOCK {renderCount} SECONDS AGO</p>
+        </span>
       </div>
       <div className="real-time-info-container">
         <span className="real-time-info">
           <strong>BLOCKS</strong>
           <span>{bestBlockHeight}</span>
-          <p>UPDATED {renderCount} SECONDS AGO</p>
         </span>
         <span className="real-time-info">
           <strong>TRANSACTIONS</strong>
           <span>{transactions}</span>
-          <p>UPDATED {renderCount} SECONDS AGO</p>
         </span>
         <span className="real-time-info">
           <strong>HASH RATE</strong>
           <span>{hashRate}</span>
-          <p>UPDATED {renderCount} SECONDS AGO</p>
         </span>
       </div>
       <TimeSeriesDashboard />

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -107,7 +107,7 @@ function Dashboard() {
       <div className="statistics-title-container">
         <h2 className="statistics-title">Statistics</h2>
         <span>Real time</span>
-        <span className="real-time-info">
+        <span className="synced-at">
           <p>LATEST BLOCK {renderCount} SECONDS AGO</p>
         </span>
       </div>


### PR DESCRIPTION
In the new interface, the timer does not update when the number of txs or the blocks height change. An example of the timer is as follows:

![Timer](https://github.com/user-attachments/assets/623099ab-c6fb-406f-8604-0d9e4843f44d)

A new version of this screen has changed the counter to the title element, instead of inside each of the realtime boxes, as follows:
![New interface](https://github.com/user-attachments/assets/4b9bf2f2-5ad7-4a42-97b4-55ea1c2867fc)


### Acceptance Criteria
- The seconds counter should be updated only when the best block height changes

### Notes
The current implementation is still not precise, because the `time` property of the `dashboard:metrics` websocket event received has no relation to the best block or transaction data.

This screen should rely on the information received through the websocket as it is now, but the server-side implementation of this event should be changed in the future to provide more precise information here.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
