### PR TITLE
fix: Token balances not updating token

### DIFF
--- a/src/components/token/TokenAutoCompleteField.js
+++ b/src/components/token/TokenAutoCompleteField.js
@@ -83,6 +83,14 @@ class TokenAutoCompleteField extends React.Component {
     document.removeEventListener('click', this.handleClick);
   }
 
+  // On component update, check if the tokenId has changed
+  // and if so, search for the new token
+  componentDidUpdate(prevProps) {
+    if (prevProps.tokenId !== this.props.tokenId) {
+      this.searchAndSelectToken();
+    }
+  }
+
   /**
    * The first component mount will need to find the token item in the elastic search
    * and then execute the data search, in case a token was already selected in the query


### PR DESCRIPTION
The "Token Balances" screen was not showing the correct custom token when it was passed as an URL parameter. This bug was tracked to the refactoring made on #319.

[Sample link](https://explorer.testnet.hathor.network/token_balances?token=00b1610499dd7f8bc76e9fdaacbfab95267866e9d0c642a685b9e15275be20a5) for testing this behavior, which currently works on testnet.

### Acceptance Criteria
- When navigating to the Token Balances screen with a `token` parameter on the URL, the token data must be exhibited.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
