### PR TITLE
Fix: Invalid opacity value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hathor-admin",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hathor-admin",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "dependencies": {
         "@hathor/wallet-lib": "1.10.0",
         "@unleash/proxy-client-react": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-admin",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=10.0.0"

--- a/src/newUi.scss
+++ b/src/newUi.scss
@@ -626,7 +626,6 @@ nav {
   gap: 4px;
   border-radius: 100px;
   border: 1px solid var(--span-purple-border);
-  opacity: 0px;
   background-color: var(--span-purple-background);
   display: flex;
   align-items: center;
@@ -2274,7 +2273,6 @@ nav {
   padding: 4px 12px 4px 12px;
   border-radius: 4px;
   border: none;
-  opacity: 0px;
   font-size: 12px;
   font-weight: 500;
   line-height: 20px;
@@ -2502,7 +2500,6 @@ a:hover {
   padding: 12px 20px 12px 20px;
   gap: 8px;
   border-radius: 4px;
-  opacity: 0px;
   background-color: transparent !important;
   color: var(--red) !important;
   border-color: var(--border-color) !important;
@@ -3166,7 +3163,6 @@ span {
   gap: 8px;
   border-radius: 4px;
   border: 1px solid var(--border-color);
-  opacity: 0px;
   font-size: 14px;
   line-height: 20px;
   letter-spacing: 0.03em;
@@ -3228,7 +3224,6 @@ th.sortable {
   align-items: center;
   width: fit-content;
   gap: 6px;
-  opacity: 0px;
   font-family: 'San Francisco Pro', sans-serif;
   font-size: 12px;
   line-height: 20px;


### PR DESCRIPTION
Some visual elements were not being displayed. Upon investigation, it was found that the reason was an invalid value of `0px` on opacity fields. In development environment this problem did not occur, as the SCSS interpreter was being less strict.

Those elements were removed.

### Acceptance Criteria
- Fixes all instances of visual elements not being displayed
- Bumps version to patch `0.21.1`, as the release process is not fully implemented in this repository #343 


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
