### PR TITLE
fix: revamp "Decode" and "Push Tx" texts under the button are too bold

### DIFF
--- a/src/newUi.scss
+++ b/src/newUi.scss
@@ -261,6 +261,7 @@ nav {
     text-transform: uppercase;
     font-family: 'Mona Sans Bold', sans-serif;
     color: var(--bold-text-color);
+    font-weight: 100;
   }
 }
 


### PR DESCRIPTION
### Acceptance Criteria
- Adjusting font weight under the button in Decode and Push Tx


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

[Vídeo 12-24 às 9.59.webm](https://github.com/user-attachments/assets/dd1a669e-a6e5-4667-880a-843c5ce25532)
