### PR TITLE
feat: Upgrades `react-router` to `v6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-loading": "2.0.3",
         "react-paginate": "8.2.0",
         "react-redux": "8.1.3",
-        "react-router-dom": "^6.29.0",
+        "react-router-dom": "6.29.0",
         "react-scripts": "3.4.4",
         "redux": "4.2.1",
         "sass": "1.77.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-loading": "2.0.3",
         "react-paginate": "8.2.0",
         "react-redux": "8.1.3",
-        "react-router-dom": "5.3.4",
+        "react-router-dom": "^6.29.0",
         "react-scripts": "3.4.4",
         "redux": "4.2.1",
         "sass": "1.77.8",
@@ -5010,6 +5010,15 @@
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.73.2.tgz",
       "integrity": "sha512-bRBcb2T+I88aG74LMVHaKms2p/T8aQd8+BZ7LuuzXlRfog1bMWWn/C5i0HVuvW4RPtXQYgIlGiXVDy9Ir1So/w==",
       "peer": true
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.22.0.tgz",
+      "integrity": "sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -12236,19 +12245,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -13437,11 +13433,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -17991,14 +17982,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -21243,39 +21226,35 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.29.0.tgz",
+      "integrity": "sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.29.0.tgz",
+      "integrity": "sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.22.0",
+        "react-router": "6.29.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -22098,11 +22077,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
@@ -25132,16 +25106,6 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -26442,11 +26406,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-loading": "2.0.3",
     "react-paginate": "8.2.0",
     "react-redux": "8.1.3",
-    "react-router-dom": "5.3.4",
+    "react-router-dom": "6.29.0",
     "react-scripts": "3.4.4",
     "redux": "4.2.1",
     "sass": "1.77.8",

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useEffect } from 'react';
 
-import { Switch, BrowserRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { axios as hathorLibAxios, config as hathorLibConfig } from '@hathor/wallet-lib';
 import { useTheme, useNewUiEnabled, useNewUiLoad } from './hooks';
@@ -106,12 +106,12 @@ function Root() {
   if (isVersionAllowed === undefined) {
     // Waiting for version
     return (
-      <Router>
+      <BrowserRouter>
         <>
           <Navigation />
           {apiLoadError ? <ErrorMessage /> : <Loading />}
         </>
-      </Router>
+      </BrowserRouter>
     );
   }
 
@@ -125,61 +125,61 @@ function Root() {
 
   return (
     <>
-      <Router>
-        <Switch>
-          <Route exact path="/transaction/:id">
+      <BrowserRouter>
+        <Routes>
+          <Route path="/transaction/:id">
             <NavigationRoute internalScreen={TransactionDetail} />
           </Route>
-          <Route exact path="/push-tx">
+          <Route path="/push-tx">
             <NavigationRoute internalScreen={PushTx} />
           </Route>
-          <Route exact path="/decode-tx">
+          <Route path="/decode-tx">
             <NavigationRoute internalScreen={DecodeTx} />
           </Route>
-          <Route exact path="/transactions">
+          <Route path="/transactions">
             <NavigationRoute internalScreen={TransactionList} />
           </Route>
-          <Route exact path="/tokens">
+          <Route path="/tokens">
             <NavigationRoute internalScreen={TokenList} />
           </Route>
-          <Route exact path="/token_balances">
+          <Route path="/token_balances">
             <NavigationRoute internalScreen={TokenBalancesList} />
           </Route>
-          <Route exact path="/token_balances">
+          <Route path="/token_balances">
             <NavigationRoute internalScreen={TokenBalancesList} />
           </Route>
-          <Route exact path="/blocks">
+          <Route path="/blocks">
             <NavigationRoute internalScreen={BlockList} />
           </Route>
-          <Route exact path="/dag" component={Dag}>
+          <Route path="/dag" component={Dag}>
             <NavigationRoute internalScreen={Dag} />
           </Route>
-          <Route exact path="/features">
+          <Route path="/features">
             <NavigationRoute internalScreen={FeatureList} />
           </Route>
-          <Route exact path="/network/:peerId?">
+          <Route path="/network/:peerId?">
             <NavigationRoute internalScreen={PeerAdmin} />
           </Route>
-          <Route exact path="/statistics">
+          <Route path="/statistics">
             <NavigationRoute internalScreen={Dashboard} />
           </Route>
-          <Route exact path="/token_detail/:tokenUID">
+          <Route path="/token_detail/:tokenUID">
             <NavigationRoute internalScreen={TokenDetail} />
           </Route>
-          <Route exact path="/address/:address">
+          <Route path="/address/:address">
             <NavigationRoute internalScreen={AddressDetail} />
           </Route>
-          <Route exact path="/nano_contract/detail/:nc_id" component={NanoContractDetail}>
+          <Route path="/nano_contract/detail/:nc_id" component={NanoContractDetail}>
             <NavigationRoute internalScreen={NanoContractDetail} />
           </Route>
-          <Route exact path="/blueprint/detail/:blueprint_id">
+          <Route path="/blueprint/detail/:blueprint_id">
             <NavigationRoute internalScreen={BlueprintDetail} />
           </Route>
-          <Route exact path="">
+          <Route path="">
             <NavigationRoute internalScreen={DashboardTx} />
           </Route>
-        </Switch>
-      </Router>
+        </Routes>
+      </BrowserRouter>
       <GDPRConsent />
     </>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -127,57 +127,51 @@ function Root() {
     <>
       <BrowserRouter>
         <Routes>
-          <Route path="/transaction/:id">
-            <NavigationRoute internalScreen={TransactionDetail} />
-          </Route>
-          <Route path="/push-tx">
-            <NavigationRoute internalScreen={PushTx} />
-          </Route>
-          <Route path="/decode-tx">
-            <NavigationRoute internalScreen={DecodeTx} />
-          </Route>
-          <Route path="/transactions">
-            <NavigationRoute internalScreen={TransactionList} />
-          </Route>
-          <Route path="/tokens">
-            <NavigationRoute internalScreen={TokenList} />
-          </Route>
-          <Route path="/token_balances">
-            <NavigationRoute internalScreen={TokenBalancesList} />
-          </Route>
-          <Route path="/token_balances">
-            <NavigationRoute internalScreen={TokenBalancesList} />
-          </Route>
-          <Route path="/blocks">
-            <NavigationRoute internalScreen={BlockList} />
-          </Route>
-          <Route path="/dag" component={Dag}>
-            <NavigationRoute internalScreen={Dag} />
-          </Route>
-          <Route path="/features">
-            <NavigationRoute internalScreen={FeatureList} />
-          </Route>
-          <Route path="/network/:peerId?">
-            <NavigationRoute internalScreen={PeerAdmin} />
-          </Route>
-          <Route path="/statistics">
-            <NavigationRoute internalScreen={Dashboard} />
-          </Route>
-          <Route path="/token_detail/:tokenUID">
-            <NavigationRoute internalScreen={TokenDetail} />
-          </Route>
-          <Route path="/address/:address">
-            <NavigationRoute internalScreen={AddressDetail} />
-          </Route>
-          <Route path="/nano_contract/detail/:nc_id" component={NanoContractDetail}>
-            <NavigationRoute internalScreen={NanoContractDetail} />
-          </Route>
-          <Route path="/blueprint/detail/:blueprint_id">
-            <NavigationRoute internalScreen={BlueprintDetail} />
-          </Route>
-          <Route path="">
-            <NavigationRoute internalScreen={DashboardTx} />
-          </Route>
+          <Route
+            path="/transaction/:id"
+            element={<NavigationRoute internalScreen={TransactionDetail} />}
+          />
+          <Route path="/push-tx" element={<NavigationRoute internalScreen={PushTx} />} />
+          <Route path="/decode-tx" element={<NavigationRoute internalScreen={DecodeTx} />} />
+          <Route
+            path="/transactions"
+            element={<NavigationRoute internalScreen={TransactionList} />}
+          />
+          <Route path="/tokens" element={<NavigationRoute internalScreen={TokenList} />} />
+          <Route
+            path="/token_balances"
+            element={<NavigationRoute internalScreen={TokenBalancesList} />}
+          />
+          <Route
+            path="/token_balances"
+            element={<NavigationRoute internalScreen={TokenBalancesList} />}
+          />
+          <Route path="/blocks" element={<NavigationRoute internalScreen={BlockList} />} />
+          <Route path="/dag" component={Dag} element={<NavigationRoute internalScreen={Dag} />} />
+          <Route path="/features" element={<NavigationRoute internalScreen={FeatureList} />} />
+          <Route
+            path="/network/:peerId?"
+            element={<NavigationRoute internalScreen={PeerAdmin} />}
+          />
+          <Route path="/statistics" element={<NavigationRoute internalScreen={Dashboard} />} />
+          <Route
+            path="/token_detail/:tokenUID"
+            element={<NavigationRoute internalScreen={TokenDetail} />}
+          />
+          <Route
+            path="/address/:address"
+            element={<NavigationRoute internalScreen={AddressDetail} />}
+          />
+          <Route
+            path="/nano_contract/detail/:nc_id"
+            component={NanoContractDetail}
+            element={<NavigationRoute internalScreen={NanoContractDetail} />}
+          />
+          <Route
+            path="/blueprint/detail/:blueprint_id"
+            element={<NavigationRoute internalScreen={BlueprintDetail} />}
+          />
+          <Route path="" element={<NavigationRoute internalScreen={DashboardTx} />} />
         </Routes>
       </BrowserRouter>
       <GDPRConsent />

--- a/src/components/AddressDetailExplorer.js
+++ b/src/components/AddressDetailExplorer.js
@@ -9,7 +9,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import hathorLib from '@hathor/wallet-lib';
 import ReactLoading from 'react-loading';
 import { find } from 'lodash';
-import { useHistory, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useNewUiEnabled } from '../hooks';
 import AddressSummary from './AddressSummary';
 import AddressHistory from './AddressHistory';
@@ -63,7 +63,7 @@ function AddressDetailExplorer() {
   );
 
   const { address } = useParams();
-  const history = useHistory();
+  const navigate = useNavigate();
   const newUiEnabled = useNewUiEnabled();
 
   /*
@@ -380,7 +380,7 @@ function AddressDetailExplorer() {
    */
   const updateTokenURL = token => {
     const newURL = pagination.current.setURLParameters({ token });
-    history.push(newURL);
+    navigate(newURL);
   };
 
   /**
@@ -389,7 +389,7 @@ function AddressDetailExplorer() {
    * @param {String} hash Hash of tx clicked
    */
   const onRowClicked = hash => {
-    history.push(`/transaction/${hash}`);
+    navigate(`/transaction/${hash}`);
   };
 
   /**

--- a/src/components/AddressDetailLegacy.js
+++ b/src/components/AddressDetailLegacy.js
@@ -303,7 +303,7 @@ class AddressDetailLegacy extends React.Component {
     const queryParams = this.pagination.obtainQueryParams();
     queryParams.token = token;
     const newURL = this.pagination.setURLParameters(queryParams);
-    this.props.history.push(newURL);
+    this.props.navigate(newURL);
   };
 
   /**
@@ -337,7 +337,7 @@ class AddressDetailLegacy extends React.Component {
    * @param {String} hash Hash of tx clicked
    */
   onRowClicked = hash => {
-    this.props.history.push(`/transaction/${hash}`);
+    this.props.navigate(`/transaction/${hash}`);
   };
 
   /**

--- a/src/components/ConditionalNavigation.js
+++ b/src/components/ConditionalNavigation.js
@@ -6,11 +6,7 @@ import { useFlag } from '@unleash/proxy-client-react';
 const ConditionalNavigation = ({ featureToggle, to, label }) => {
   return useFlag(featureToggle) ? (
     <span className="nav-item">
-      <NavLink
-        to={to}
-        className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-        activeStyle={{ fontWeight: 'bold' }}
-      >
+      <NavLink to={to} className={({ isActive }) => `nav-link ${isActive && 'active'}`}>
         {label}
       </NavLink>
     </span>

--- a/src/components/ConditionalNavigation.js
+++ b/src/components/ConditionalNavigation.js
@@ -8,7 +8,6 @@ const ConditionalNavigation = ({ featureToggle, to, label }) => {
     <span className="nav-item">
       <NavLink
         to={to}
-        exact
         className="nav-link"
         activeClassName="active"
         activeStyle={{ fontWeight: 'bold' }}

--- a/src/components/ConditionalNavigation.js
+++ b/src/components/ConditionalNavigation.js
@@ -8,8 +8,7 @@ const ConditionalNavigation = ({ featureToggle, to, label }) => {
     <span className="nav-item">
       <NavLink
         to={to}
-        className="nav-link"
-        activeClassName="active"
+        className={({ isActive }) => `nav-link ${isActive && 'active'}`}
         activeStyle={{ fontWeight: 'bold' }}
       >
         {label}

--- a/src/components/ConditionalNavigation.js
+++ b/src/components/ConditionalNavigation.js
@@ -6,7 +6,7 @@ import { useFlag } from '@unleash/proxy-client-react';
 const ConditionalNavigation = ({ featureToggle, to, label }) => {
   return useFlag(featureToggle) ? (
     <span className="nav-item">
-      <NavLink to={to} className={({ isActive }) => `nav-link ${isActive && 'active'}`}>
+      <NavLink to={to} className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>
         {label}
       </NavLink>
     </span>

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -113,7 +113,6 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/"
-                  exact
                   className="nav-link"
                   activeClassName="active"
                   activeStyle={{ fontWeight: 'bold' }}
@@ -153,7 +152,6 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/network"
-                  exact
                   className="nav-link"
                   activeClassName="active"
                   activeStyle={{ fontWeight: 'bold' }}
@@ -164,7 +162,6 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/statistics"
-                  exact
                   className="nav-link"
                   activeClassName="active"
                   activeStyle={{ fontWeight: 'bold' }}
@@ -185,16 +182,16 @@ function Navigation() {
                   <ArrorDownNavItem className="dropdown-icon" />
                 </span>
                 <div className="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <NavLink to="/decode-tx/" exact className="nav-link">
+                  <NavLink to="/decode-tx/" className="nav-link">
                     Decode Tx
                   </NavLink>
-                  <NavLink to="/push-tx/" exact className="nav-link">
+                  <NavLink to="/push-tx/" className="nav-link">
                     Push Tx
                   </NavLink>
-                  <NavLink to="/dag/" exact className="nav-link">
+                  <NavLink to="/dag/" className="nav-link">
                     DAG
                   </NavLink>
-                  <NavLink to="/features/" exact className="nav-link">
+                  <NavLink to="/features/" className="nav-link">
                     Features
                   </NavLink>
                 </div>
@@ -286,7 +283,6 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/"
-                  exact
                   className="nav-link"
                   activeClassName="active"
                   activeStyle={{ fontWeight: 'bold' }}
@@ -325,7 +321,6 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/network"
-                  exact
                   className="nav-link"
                   activeClassName="active"
                   activeStyle={{ fontWeight: 'bold' }}
@@ -336,7 +331,6 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/statistics"
-                  exact
                   className="nav-link"
                   activeClassName="active"
                   activeStyle={{ fontWeight: 'bold' }}
@@ -356,16 +350,16 @@ function Navigation() {
                   Tools
                 </span>
                 <div className="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <NavLink to="/decode-tx/" exact className="nav-link">
+                  <NavLink to="/decode-tx/" className="nav-link">
                     Decode Tx
                   </NavLink>
-                  <NavLink to="/push-tx/" exact className="nav-link">
+                  <NavLink to="/push-tx/" className="nav-link">
                     Push Tx
                   </NavLink>
-                  <NavLink to="/dag/" exact className="nav-link">
+                  <NavLink to="/dag/" className="nav-link">
                     DAG
                   </NavLink>
-                  <NavLink to="/features/" exact className="nav-link">
+                  <NavLink to="/features/" className="nav-link">
                     Features
                   </NavLink>
                 </div>

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -113,8 +113,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/"
-                  className="nav-link"
-                  activeClassName="active"
+                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
                   activeStyle={{ fontWeight: 'bold' }}
                 >
                   Home
@@ -152,8 +151,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/network"
-                  className="nav-link"
-                  activeClassName="active"
+                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
                   activeStyle={{ fontWeight: 'bold' }}
                 >
                   Network
@@ -162,8 +160,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/statistics"
-                  className="nav-link"
-                  activeClassName="active"
+                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
                   activeStyle={{ fontWeight: 'bold' }}
                 >
                   Statistics
@@ -283,8 +280,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/"
-                  className="nav-link"
-                  activeClassName="active"
+                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
                   activeStyle={{ fontWeight: 'bold' }}
                 >
                   Transactions
@@ -321,8 +317,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/network"
-                  className="nav-link"
-                  activeClassName="active"
+                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
                   activeStyle={{ fontWeight: 'bold' }}
                 >
                   Network
@@ -331,8 +326,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/statistics"
-                  className="nav-link"
-                  activeClassName="active"
+                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
                   activeStyle={{ fontWeight: 'bold' }}
                 >
                   Statistics

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -111,7 +111,10 @@ function Navigation() {
           <div className="nav-tabs-container hide-tabs">
             <ul className="navbar-nav me-auto">
               <li className="nav-item">
-                <NavLink to="/" className={({ isActive }) => `nav-link ${isActive && 'active'}`}>
+                <NavLink
+                  to="/"
+                  className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
+                >
                   Home
                 </NavLink>
               </li>
@@ -147,7 +150,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/network"
-                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
+                  className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
                 >
                   Network
                 </NavLink>
@@ -155,7 +158,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/statistics"
-                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
+                  className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
                 >
                   Statistics
                 </NavLink>
@@ -272,7 +275,10 @@ function Navigation() {
           <div className="collapse navbar-collapse" id="navbarSupportedContent">
             <ul className="navbar-nav me-auto">
               <li className="nav-item">
-                <NavLink to="/" className={({ isActive }) => `nav-link ${isActive && 'active'}`}>
+                <NavLink
+                  to="/"
+                  className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
+                >
                   Transactions
                 </NavLink>
               </li>
@@ -307,7 +313,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/network"
-                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
+                  className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
                 >
                   Network
                 </NavLink>
@@ -315,7 +321,7 @@ function Navigation() {
               <li className="nav-item">
                 <NavLink
                   to="/statistics"
-                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
+                  className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
                 >
                   Statistics
                 </NavLink>

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useRef, useState } from 'react';
-import { NavLink, Link, useHistory } from 'react-router-dom';
+import { NavLink, Link, useNavigate } from 'react-router-dom';
 import hathorLib from '@hathor/wallet-lib';
 import { useFlag } from '@unleash/proxy-client-react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -32,7 +32,7 @@ import { toggleTheme } from '../actions';
 import NewHathorAlert from './NewHathorAlert';
 
 function Navigation() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const alertErrorRef = useRef(null);
   const txSearchRef = useRef(null);
@@ -65,13 +65,13 @@ function Navigation() {
       const regex = /[A-Fa-f\d]{64}/g;
       if (regex.test(text)) {
         // It's a valid hash
-        history.push(`/transaction/${text}`);
+        navigate(`/transaction/${text}`);
       } else {
         const network = hathorLib.config.getNetwork();
         const addressObj = new hathorLib.Address(text, { network });
         if (addressObj.isValid()) {
           // It's a valid address
-          history.push(`/address/${text}`);
+          navigate(`/address/${text}`);
         } else {
           showError();
         }

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -111,11 +111,7 @@ function Navigation() {
           <div className="nav-tabs-container hide-tabs">
             <ul className="navbar-nav me-auto">
               <li className="nav-item">
-                <NavLink
-                  to="/"
-                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-                  activeStyle={{ fontWeight: 'bold' }}
-                >
+                <NavLink to="/" className={({ isActive }) => `nav-link ${isActive && 'active'}`}>
                   Home
                 </NavLink>
               </li>
@@ -152,7 +148,6 @@ function Navigation() {
                 <NavLink
                   to="/network"
                   className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-                  activeStyle={{ fontWeight: 'bold' }}
                 >
                   Network
                 </NavLink>
@@ -161,7 +156,6 @@ function Navigation() {
                 <NavLink
                   to="/statistics"
                   className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-                  activeStyle={{ fontWeight: 'bold' }}
                 >
                   Statistics
                 </NavLink>
@@ -278,11 +272,7 @@ function Navigation() {
           <div className="collapse navbar-collapse" id="navbarSupportedContent">
             <ul className="navbar-nav me-auto">
               <li className="nav-item">
-                <NavLink
-                  to="/"
-                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-                  activeStyle={{ fontWeight: 'bold' }}
-                >
+                <NavLink to="/" className={({ isActive }) => `nav-link ${isActive && 'active'}`}>
                   Transactions
                 </NavLink>
               </li>
@@ -318,7 +308,6 @@ function Navigation() {
                 <NavLink
                   to="/network"
                   className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-                  activeStyle={{ fontWeight: 'bold' }}
                 >
                   Network
                 </NavLink>
@@ -327,7 +316,6 @@ function Navigation() {
                 <NavLink
                   to="/statistics"
                   className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-                  activeStyle={{ fontWeight: 'bold' }}
                 >
                   Statistics
                 </NavLink>

--- a/src/components/Network.js
+++ b/src/components/Network.js
@@ -77,7 +77,7 @@ class Network extends React.Component {
   }
 
   onPeerChange(peerId) {
-    this.props.history.push(`/network/${peerId}`);
+    this.props.navigate(`/network/${peerId}`);
     clearInterval(this.loadTimer);
     this.setState({ peerId, loaded: false }, () => {
       this.loadData();

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -58,8 +58,7 @@ function Sidebar({ close, open }) {
               <li className="nav-item item-sidebar">
                 <NavLink
                   to="/"
-                  className="nav-link"
-                  activeClassName="active"
+                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
                   activeStyle={{ fontWeight: 'bold' }}
                 >
                   Home
@@ -100,8 +99,7 @@ function Sidebar({ close, open }) {
               <li className="nav-item item-sidebar">
                 <NavLink
                   to="/network"
-                  className="nav-link"
-                  activeClassName="active"
+                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
                   activeStyle={{ fontWeight: 'bold' }}
                 >
                   Network
@@ -110,8 +108,7 @@ function Sidebar({ close, open }) {
               <li className="nav-item item-sidebar">
                 <NavLink
                   to="/statistics"
-                  className="nav-link"
-                  activeClassName="active"
+                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
                   activeStyle={{ fontWeight: 'bold' }}
                 >
                   Statistics

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -56,7 +56,10 @@ function Sidebar({ close, open }) {
           <div className="aside-tabs-container">
             <ul className="navbar-nav me-auto">
               <li className="nav-item item-sidebar">
-                <NavLink to="/" className={({ isActive }) => `nav-link ${isActive && 'active'}`}>
+                <NavLink
+                  to="/"
+                  className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
+                >
                   Home
                 </NavLink>
               </li>
@@ -95,7 +98,7 @@ function Sidebar({ close, open }) {
               <li className="nav-item item-sidebar">
                 <NavLink
                   to="/network"
-                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
+                  className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
                 >
                   Network
                 </NavLink>
@@ -103,7 +106,7 @@ function Sidebar({ close, open }) {
               <li className="nav-item item-sidebar">
                 <NavLink
                   to="/statistics"
-                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
+                  className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}
                 >
                   Statistics
                 </NavLink>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -58,7 +58,6 @@ function Sidebar({ close, open }) {
               <li className="nav-item item-sidebar">
                 <NavLink
                   to="/"
-                  exact
                   className="nav-link"
                   activeClassName="active"
                   activeStyle={{ fontWeight: 'bold' }}
@@ -101,7 +100,6 @@ function Sidebar({ close, open }) {
               <li className="nav-item item-sidebar">
                 <NavLink
                   to="/network"
-                  exact
                   className="nav-link"
                   activeClassName="active"
                   activeStyle={{ fontWeight: 'bold' }}
@@ -112,7 +110,6 @@ function Sidebar({ close, open }) {
               <li className="nav-item item-sidebar">
                 <NavLink
                   to="/statistics"
-                  exact
                   className="nav-link"
                   activeClassName="active"
                   activeStyle={{ fontWeight: 'bold' }}
@@ -132,16 +129,16 @@ function Sidebar({ close, open }) {
                   <div>
                     <ul style={{ listStyleType: 'none', padding: 0, margin: 0 }}>
                       <li>
-                        <NavLink to="/decode-tx/" exact className="nav-link">
+                        <NavLink to="/decode-tx/" className="nav-link">
                           Decode Tx
                         </NavLink>
-                        <NavLink to="/push-tx/" exact className="nav-link">
+                        <NavLink to="/push-tx/" className="nav-link">
                           Push Tx
                         </NavLink>
-                        <NavLink to="/dag/" exact className="nav-link">
+                        <NavLink to="/dag/" className="nav-link">
                           DAG
                         </NavLink>
-                        <NavLink to="/features/" exact className="nav-link">
+                        <NavLink to="/features/" className="nav-link">
                           Features
                         </NavLink>
                       </li>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -56,11 +56,7 @@ function Sidebar({ close, open }) {
           <div className="aside-tabs-container">
             <ul className="navbar-nav me-auto">
               <li className="nav-item item-sidebar">
-                <NavLink
-                  to="/"
-                  className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-                  activeStyle={{ fontWeight: 'bold' }}
-                >
+                <NavLink to="/" className={({ isActive }) => `nav-link ${isActive && 'active'}`}>
                   Home
                 </NavLink>
               </li>
@@ -100,7 +96,6 @@ function Sidebar({ close, open }) {
                 <NavLink
                   to="/network"
                   className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-                  activeStyle={{ fontWeight: 'bold' }}
                 >
                   Network
                 </NavLink>
@@ -109,7 +104,6 @@ function Sidebar({ close, open }) {
                 <NavLink
                   to="/statistics"
                   className={({ isActive }) => `nav-link ${isActive && 'active'}`}
-                  activeStyle={{ fontWeight: 'bold' }}
                 >
                   Statistics
                 </NavLink>

--- a/src/components/token/TokenBalanceRow.js
+++ b/src/components/token/TokenBalanceRow.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { numberUtils } from '@hathor/wallet-lib';
 import { useSelector } from 'react-redux';
@@ -14,7 +14,7 @@ import { useIsMobile, useNewUiEnabled } from '../../hooks';
 import EllipsiCell from '../EllipsiCell';
 
 function TokenBalanceRow({ tokenId, address, total, unlocked, locked }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const newUiEnabled = useNewUiEnabled();
   const isMobile = useIsMobile();
   const decimalPlaces = useSelector(state => state.serverInfo.decimal_places);
@@ -25,7 +25,7 @@ function TokenBalanceRow({ tokenId, address, total, unlocked, locked }) {
    * @param {String} uid UID of token clicked
    */
   const onRowClicked = () => {
-    history.push(`/address/${address}?token=${tokenId}`);
+    navigate(`/address/${address}?token=${tokenId}`);
   };
 
   const renderUi = () => (

--- a/src/components/token/TokenBalances.js
+++ b/src/components/token/TokenBalances.js
@@ -8,7 +8,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { get, last, find, isEmpty } from 'lodash';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { numberUtils, constants as hathorLibConstants } from '@hathor/wallet-lib';
 import { useSelector } from 'react-redux';
 import { useNewUiEnabled } from '../../hooks';
@@ -22,7 +22,7 @@ import TokenAutoCompleteField from './TokenAutoCompleteField';
  * Displays custom tokens in a table with pagination buttons and a search bar.
  */
 function TokenBalances({ maintenanceMode }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const newUiEnabled = useNewUiEnabled();
   const serverInfo = useSelector(state => state.serverInfo);
 
@@ -161,9 +161,9 @@ function TokenBalances({ maintenanceMode }) {
         order: newOrder,
       });
 
-      history.push(newURL);
+      navigate(newURL);
     },
-    [history]
+    [navigate]
   );
 
   /**

--- a/src/components/token/TokenRow.js
+++ b/src/components/token/TokenRow.js
@@ -8,13 +8,13 @@
 import React from 'react';
 import hathorLib from '@hathor/wallet-lib';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import dateFormatter from '../../utils/date';
 import { useIsMobile, useNewUiEnabled } from '../../hooks';
 import EllipsiCell from '../EllipsiCell';
 
 function TokenRow({ token }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const newUiEnabled = useNewUiEnabled();
   const isMobile = useIsMobile();
 
@@ -24,7 +24,7 @@ function TokenRow({ token }) {
    * @param {String} uid UID of token clicked
    */
   const onRowClicked = uid => {
-    history.push(`/token_detail/${uid}`);
+    navigate(`/token_detail/${uid}`);
   };
 
   const Symbol = ({ children }) => {

--- a/src/components/token/Tokens.js
+++ b/src/components/token/Tokens.js
@@ -8,7 +8,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get, last, find, isEmpty } from 'lodash';
-import { withRouter } from 'react-router-dom';
 import TokensTable from './TokensTable';
 import TokenSearchField from './TokenSearchField';
 import tokensApi from '../../api/tokensApi';
@@ -176,7 +175,7 @@ class Tokens extends React.Component {
       order: this.state.order,
     });
 
-    this.props.history.push(newURL);
+    this.props.navigate(newURL);
   };
 
   /**
@@ -325,4 +324,4 @@ Tokens.propTypes = {
   maintenanceMode: PropTypes.bool.isRequired,
 };
 
-export default withRouter(Tokens);
+export default Tokens;

--- a/src/components/token/Tokens.js
+++ b/src/components/token/Tokens.js
@@ -316,11 +316,11 @@ class Tokens extends React.Component {
 }
 
 /**
- * title: Tokens Page title
+ * title: Tokens Page title, used only in the old UI
  * maintenanceMode: A "circuit breaker" to remove additional load when a problem is affecting explorer-service or its downstream services
  */
 Tokens.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   maintenanceMode: PropTypes.bool.isRequired,
 };
 

--- a/src/components/tx/TxRow.js
+++ b/src/components/tx/TxRow.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import hathorLib from '@hathor/wallet-lib';
 import dateFormatter from '../../utils/date';
 import { useNewUiEnabled } from '../../hooks';
@@ -14,10 +14,10 @@ import EllipsiCell from '../EllipsiCell';
 
 const TxRow = ({ tx, ellipsis }) => {
   const newUiEnabled = useNewUiEnabled();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleClickTr = hash => {
-    history.push(`/transaction/${hash}`);
+    navigate(`/transaction/${hash}`);
   };
 
   const renderNewUi = () => (

--- a/src/screens/AddressDetail.js
+++ b/src/screens/AddressDetail.js
@@ -7,8 +7,7 @@
 
 import React from 'react';
 import { useFlag } from '@unleash/proxy-client-react';
-import { useHistory } from 'react-router-dom/cjs/react-router-dom';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import AddressDetailExplorer from '../components/AddressDetailExplorer';
 import AddressDetailLegacy from '../components/AddressDetailLegacy';
 import { UNLEASH_ADDRESS_DETAIL_BASE_FEATURE_FLAG } from '../constants';
@@ -17,7 +16,7 @@ import ErrorMessageWithIcon from '../components/error/ErrorMessageWithIcon';
 const AddressDetail = () => {
   const maintenanceMode = useFlag(`${UNLEASH_ADDRESS_DETAIL_BASE_FEATURE_FLAG}.maintenance`);
   const latestMode = useFlag(`${UNLEASH_ADDRESS_DETAIL_BASE_FEATURE_FLAG}.latest`);
-  const history = useHistory();
+  const navigate = useNavigate();
   const params = useParams();
 
   if (maintenanceMode) {
@@ -30,7 +29,7 @@ const AddressDetail = () => {
     return <AddressDetailExplorer />;
   }
 
-  return <AddressDetailLegacy history={history} match={{ params }} />;
+  return <AddressDetailLegacy navigate={navigate} match={{ params }} />;
 };
 
 export default AddressDetail;

--- a/src/screens/PeerAdmin.js
+++ b/src/screens/PeerAdmin.js
@@ -6,18 +6,18 @@
  */
 
 import React from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useNewUiEnabled } from '../hooks';
 import Network from '../components/Network';
 
 function PeerAdmin() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const params = useParams();
   const newUiEnabled = useNewUiEnabled();
 
   const renderUi = () => (
     <div className="content-wrapper">
-      <Network history={history} match={params} />
+      <Network navigate={navigate} match={params} />
     </div>
   );
 
@@ -25,7 +25,7 @@ function PeerAdmin() {
     <div className="network-wrapper">
       <h2 className="network-title">Network</h2>
       <div>
-        <Network history={history} match={params} newUiEnabled={newUiEnabled} />
+        <Network navigate={navigate} match={params} newUiEnabled={newUiEnabled} />
       </div>
     </div>
   );

--- a/src/screens/TokenList.js
+++ b/src/screens/TokenList.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { useFlag } from '@unleash/proxy-client-react';
+import { useNavigate } from 'react-router-dom';
 import Tokens from '../components/token/Tokens';
 import { UNLEASH_TOKENS_BASE_FEATURE_FLAG } from '../constants';
 import { useNewUiEnabled } from '../hooks';
@@ -14,6 +15,7 @@ import { useNewUiEnabled } from '../hooks';
 const TokenList = () => {
   const maintenanceMode = useFlag(`${UNLEASH_TOKENS_BASE_FEATURE_FLAG}.maintenance`);
   const newUiEnabled = useNewUiEnabled();
+  const navigate = useNavigate();
 
   const renderNewUi = () => {
     return (
@@ -21,7 +23,12 @@ const TokenList = () => {
         <br />
         <div className="container-title-page">
           <p className="title-page">Tokens</p>
-          <Tokens maintenanceMode={maintenanceMode} newUiEnabled={newUiEnabled} />
+          <Tokens
+            title={'Tokens'}
+            maintenanceMode={maintenanceMode}
+            newUiEnabled={newUiEnabled}
+            navigate={navigate}
+          />
         </div>
       </div>
     );
@@ -30,7 +37,12 @@ const TokenList = () => {
   const renderUi = () => {
     return (
       <div className="content-wrapper">
-        <Tokens title={'Tokens'} maintenanceMode={maintenanceMode} newUiEnabled={newUiEnabled} />
+        <Tokens
+          title={'Tokens'}
+          maintenanceMode={maintenanceMode}
+          newUiEnabled={newUiEnabled}
+          navigate={navigate}
+        />
       </div>
     );
   };

--- a/src/screens/TokenList.js
+++ b/src/screens/TokenList.js
@@ -24,7 +24,6 @@ const TokenList = () => {
         <div className="container-title-page">
           <p className="title-page">Tokens</p>
           <Tokens
-            title={'Tokens'}
             maintenanceMode={maintenanceMode}
             newUiEnabled={newUiEnabled}
             navigate={navigate}


### PR DESCRIPTION
This PR upgrades the React Router from version `5.x` to `v6`. Below are the guides followed to implement the necessary adaptations:
- [Migration guide](https://reactrouter.com/en/main/upgrading/v5) from v5 to v6
- Similar upgrade on the Desktop Wallet repository: https://github.com/HathorNetwork/hathor-wallet/pull/555

### Acceptance Criteria
- Continues the upgrade started on #289
- Upgrades the React Router to the latest stable version v6

### Notes
- Most of the file changes were due to renaming all instances of `useHistory` to `useNavigate` on the screens.
- For a smaller scope and easier reviewing, the available [future proofing flags](https://reactrouter.com/6.29.0/upgrading/future) will not be implemented in this PR, despite being available at the current version.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
