### PR TITLE
fix: deploy action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,8 @@ jobs:
           node-version: 20.x
 
       - name: Cache node modules
-        # https://github.com/actions/cache/releases/tag/v4.0.2
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        # https://github.com/actions/cache/releases/tag/v4.2.2
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
The `4.0.2` version of the `actions` GitHub action we've been using for the last months ( since #279 ) has been disabled by some reason that still needs to be understood.

Since we were pinning the version directly to [the commit hash `0c45773b623bea8c8e75f6c82b208c3cf94ea4f9`](https://github.com/actions/cache/commit/0c45773b623bea8c8e75f6c82b208c3cf94ea4f9), the deploy command suddenly stopped working when the [tag `4.0.2`](https://github.com/actions/cache/releases/tag/v4.0.2) somehow ceased to be available. Re-running the workflow did not work, even though both the tag and commit are still available through the links above. 

An issue to understand this change will be opened to further investigate, since all other actions in this repository workflow use hash-locked versions. But for this PR, the focus is on deploying the latest version of the Explorer to `testnet`. So the latest `v4.2.2` is being used, still maintaining the hash-lock pattern.

### Acceptance Criteria
- Upgrade the workflow `actions` version to the latest minor: `v4.2.2`


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
