### PR TITLE
fix: `cjs` file handling for axios

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -27,12 +27,18 @@ module.exports = function override(config) {
   };
 
   // Relaxing js/mjs extension resolve
-  config.module.rules.push({
-    test: /\.m?js/, // Apply this rule to .js and .mjs files
-    resolve: {
-      fullySpecified: false, // Allow resolving modules without fully specifying the file extension
+  config.module.rules.push(
+    {
+      test: /\.m?js/, // Apply this rule to .js and .mjs files
+      resolve: {
+        fullySpecified: false, // Allow resolving modules without fully specifying the file extension
+      },
     },
-  });
+    {
+      test: /\.cjs/, // Apply this rule to .cjs files
+      type: 'javascript/auto',
+    }
+  );
 
   // Solves process and buffer issues for WebPack
   const webpack = require('webpack');


### PR DESCRIPTION
### Summary
We were having errors when trying to load the "Transaction Details" screen for a nano contract tx. This was happening because the module for Axios was not being found by the browser, and instead if was being fed only a string containing the module path.

A fix had to be implemented in the `config-override.js` file to instruct WebPack v5 on where to find the module, which is in a file format we did not configure previously on the CRA upgrade ( #386 ).

### Acceptance Criteria
- The "Nano Contract Overview" section of a nc transaction should be exhibited on the "Transaction Details" screen


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
