### PR TITLE
fix: display NFTs token info in three columns

### DIFF
--- a/src/components/token/TokenDetailsTop.js
+++ b/src/components/token/TokenDetailsTop.js
@@ -38,7 +38,7 @@ const TokenDetailsTop = props => {
           </p>
         </div>
         <TokenAlerts token={token} />
-        <div className="token-medium-containers">
+        <div className="d-flex token-medium-containers">
           <div className="d-flex flex-column justify-content-between">
             <TokenInfo token={token} metadataLoaded={metadataLoaded} />
           </div>

--- a/src/newUi.scss
+++ b/src/newUi.scss
@@ -545,8 +545,10 @@ nav {
     margin-top: 16px;
     justify-content: center;
     gap: 16px;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+  }
+
+  .token-medium-containers > div {
+    flex: 1 1 0px;
   }
 
   .token-new-general-info {


### PR DESCRIPTION
### Acceptance Criteria
- NFTs display should show as third column on desktops, each taking 1/3 of the space.
- When it's not an NFT, display just two sections, each taking 50% of the space ([example](https://explorer.hathor.network/token_detail/000001139655b68f6adbff6f0fc164d2164a2905868f13ed04382a55b26374fe)).
- On mobile, token sections should be one under the other.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

Currently: https://explorer.hathor.network/token_detail/000000005f7095d4f0180b2238d7a9f7113c115de4b001eef3aef04289d08a5e
![image](https://github.com/user-attachments/assets/b96333ff-445a-4e3f-9531-c22c39b7f92b)

Fixed:
![image](https://github.com/user-attachments/assets/61263664-48b4-42c2-ac72-a8520ca17297)
