### PR TITLE
chore: use testnet-golf specific domains

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -79,10 +79,10 @@ case $site in
     CLOUDFRONT_ID=E1NI147Y237J4M
     ;;
   testnet)
-    FULLNODE_HOST=node.explorer.testnet.hathor.network
+    FULLNODE_HOST=node.explorer.golf.testnet.hathor.network
     REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
     REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
-    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.testnet.hathor.network/
+    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.golf.testnet.hathor.network/
     REACT_APP_TIMESERIES_DASHBOARD_ID=35379840-e8c5-11ec-a7f2-0fee9be0d8ee
     REACT_APP_NETWORK=testnet
     S3_BUCKET=hathor-testnet-golf-public-explorer


### PR DESCRIPTION
### Acceptance Criteria
- We should use the testnet-golf domains for the fullnodes and explorer-service


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
