### PR TITLE
fix: address misaligned in address page

### DIFF
--- a/src/components/AddressSummary.js
+++ b/src/components/AddressSummary.js
@@ -35,9 +35,7 @@ class AddressSummary extends React.Component {
         <div className="summary-main-info alter-background">
           <div className="summary-main-info-container ">
             <div className="address-container-title summary-container-title-purple">Address</div>
-            <div className="address-div">
-              <p>{this.props.address}</p>
-            </div>
+            <div className="address-div">{this.props.address}</div>
           </div>
           <div className="summary-main-info-container">
             <div className="address-container-title summary-container-title-purple">


### PR DESCRIPTION
Before:
<img width="473" height="176" alt="image" src="https://github.com/user-attachments/assets/bd2ed2e6-ee6d-4178-89d8-7e26e713f5e6" />

After:
<img width="460" height="147" alt="image" src="https://github.com/user-attachments/assets/9689c627-aa23-41c2-86e8-7f708ec3e235" />
