### PR TITLE
fix: show token detail screen only after token info is loaded

### DIFF
--- a/src/screens/TokenDetail.js
+++ b/src/screens/TokenDetail.js
@@ -39,6 +39,7 @@ function TokenDetail() {
    */
   const [token, setToken] = useState(null);
   const [errorMessage, setErrorMessage] = useState('');
+  const [tokenInfoLoaded, setTokenInfoLoaded] = useState(false);
   const [metadataLoaded, setMetadataLoaded] = useState(false);
 
   const { tokenUID } = useParams();
@@ -68,6 +69,7 @@ function TokenDetail() {
       canMelt: response.melt.length > 0,
       transactionsCount: response.transactions_count,
     }));
+    setTokenInfoLoaded(true);
   };
 
   const updateTokenMetadata = async id => {
@@ -131,7 +133,7 @@ function TokenDetail() {
     );
   }
 
-  if (!token) return null;
+  if (!token || !tokenInfoLoaded) return null;
 
   const renderNewUi = () => (
     <div className="flex align-items-center token-details-container">


### PR DESCRIPTION
### Context

The TokenDetail screen executes two requests (token info and token metadata), but depends on only one (token info) to render correctly. 

We are currently rendering the TokenDetail screen after the state object `token` exists, but the metadata load also updates this state object.

If the metadata request finishes first, we will try to render the screen without the data required, crashing the screen.

We must wait for the token info to load before rendering the screen.

### Acceptance Criteria
- Fix async load error when metadata is loaded before the token details


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
