### PR TITLE
feat: add testnet-shielded-outputs and remove deprecated testnets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,32 +50,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  deploy-testnet-explorer:
-    if: github.ref == 'refs/heads/release'
-    needs: dependencies
-    runs-on: ubuntu-latest
-    steps:
-      # https://github.com/actions/checkout/releases/tag/v4.2.2
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: ./.github/actions/deploy-explorer
-        with:
-          site: testnet
-          aws-region: us-east-1
-          aws-role: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRoleTestnet
-
-  deploy-testnet-hotel-explorer:
-    if: github.ref == 'refs/heads/release'
-    needs: dependencies
-    runs-on: ubuntu-latest
-    steps:
-      # https://github.com/actions/checkout/releases/tag/v4.2.2
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: ./.github/actions/deploy-explorer
-        with:
-          site: testnet-hotel
-          aws-region: us-east-1
-          aws-role: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRoleTestnetHotel
-
   deploy-testnet-india-explorer:
     if: github.ref == 'refs/heads/release'
     needs: dependencies
@@ -140,3 +114,16 @@ jobs:
           site: mainnet
           aws-region: us-east-1
           aws-role: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRoleMainnet
+
+  deploy-testnet-shielded-outputs-explorer:
+    if: github.ref == 'refs/heads/release'
+    needs: dependencies
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./.github/actions/deploy-explorer
+        with:
+          site: testnet-shielded-outputs
+          aws-region: us-east-1
+          aws-role: arn:aws:iam::264627803661:role/ExplorerGitHubActionsRoleTestnetShieldedOutputs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+.PHONY: install
+install:
+	npm install
+
 .PHONY: build
-build:
+build: install
 	./scripts/deploy.sh $(site) build $(aws_profile)
 
 .PHONY: sync

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -20,11 +20,17 @@ module.exports = function override(config) {
     assert: stdLib.assert,
     process: stdLib.process,
     zlib: stdLib.zlib,
+    os: false,
   };
 
   config.resolve.alias = {
     // Add an alias for our buffer shim
     'buffer-shim': path.resolve(__dirname, 'src/buffer-shim.js'),
+    // @hathor/ct-crypto-node is a Node-only NAPI addon used by wallet-lib's
+    // shielded crypto provider. The explorer never calls that code path, so
+    // stub it to an empty module to avoid pulling Node core modules into the
+    // browser bundle.
+    '@hathor/ct-crypto-node': false,
   };
 
   // Relaxing js/mjs extension resolve

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "react-redux": "9.2.0",
         "react-router-dom": "6.29.0",
         "react-scripts": "5.0.1",
-        "sass": "1.77.8",
+        "sass": "1.97.3",
         "unleash-proxy-client": "1.11.0",
         "viz.js": "2.1.2"
       },
@@ -3318,6 +3318,315 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -7564,6 +7873,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -10203,9 +10522,10 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -13556,6 +13876,13 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-forge": {
       "version": "1.3.2",
@@ -17673,12 +18000,13 @@
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
     },
     "node_modules/sass": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
+      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+      "license": "MIT",
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
@@ -17686,6 +18014,9 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/sass-loader": {
@@ -17723,6 +18054,34 @@
         "sass-embedded": {
           "optional": true
         }
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.26.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@hathor/wallet-lib": "2.12.0",
+        "@hathor/wallet-lib": "^0.0.3-shielded",
         "@reduxjs/toolkit": "2.5.1",
         "@unleash/proxy-client-react": "1.0.4",
         "axios": "1.8.2",
@@ -2672,10 +2672,29 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hathor/ct-crypto-node": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@hathor/ct-crypto-node/-/ct-crypto-node-0.4.0.tgz",
+      "integrity": "sha512-9BxFWvUNOONOthE+OalMsqLrDeJDXCwk8a1cYy0I6P83RtXtr7CzMI35dqrqoQ6juUNTIcC17ykLrPyJ7V+e7w==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@hathor/wallet-lib": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-2.12.0.tgz",
-      "integrity": "sha512-w+BlUFxURAc/t/iTfP3+5DUChHhvPPCR4vW8keKLnnKBUcKfmtpMKfIezt3P2LtknbHUibWxxxEufcw6q/qYOQ==",
+      "version": "0.0.3-shielded",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.0.3-shielded.tgz",
+      "integrity": "sha512-5An/d4RKYDoxgOUfMuIfjzKJ7OCtig2AtJFQc2fR9GS82WKPTy1tR+7zDwTwZoOUWOXOgZ4aTsKemaTk6iBRdA==",
       "license": "MIT",
       "dependencies": {
         "axios": "1.7.7",
@@ -2692,6 +2711,9 @@
       "engines": {
         "node": ">=22.0.0",
         "npm": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "@hathor/ct-crypto-node": "0.4.0"
       }
     },
     "node_modules/@hathor/wallet-lib/node_modules/axios": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@hathor/wallet-lib": "2.12.0",
+    "@hathor/wallet-lib": "^0.0.3-shielded",
     "@reduxjs/toolkit": "2.5.1",
     "@unleash/proxy-client-react": "1.0.4",
     "axios": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-redux": "9.2.0",
     "react-router-dom": "6.29.0",
     "react-scripts": "5.0.1",
-    "sass": "1.77.8",
+    "sass": "1.97.3",
     "unleash-proxy-client": "1.11.0",
     "viz.js": "2.1.2"
   },

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -56,28 +56,6 @@ case $site in
     S3_BUCKET=hathor-ekvilibro-mainnet-public-explorer
     CLOUDFRONT_ID=E1NI147Y237J4M
     ;;
-  testnet)
-    FULLNODE_HOST=node.explorer.golf.testnet.hathor.network
-    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
-    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
-    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.golf.testnet.hathor.network/
-    REACT_APP_TIMESERIES_DASHBOARD_ID=35379840-e8c5-11ec-a7f2-0fee9be0d8ee
-    REACT_APP_NETWORK=testnet
-    S3_BUCKET=hathor-testnet-golf-public-explorer
-    CLOUDFRONT_ID=E2TGO5SVP34CC3
-    ;;
-  testnet-hotel)
-    FULLNODE_HOST=node.explorer.hotel.testnet.hathor.network
-    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
-    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
-    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.hotel.testnet.hathor.network/
-    REACT_APP_TIMESERIES_DASHBOARD_ID=1c601ee9-899e-4b42-8a9c-fa5d4adb1390
-    # This one is currently only used to form the names of feature flags,
-    # so it made sense to keep it as testnet
-    REACT_APP_NETWORK=testnet
-    S3_BUCKET=hathor-testnet-hotel-public-explorer
-    CLOUDFRONT_ID=E2G33O3YIT0NZ8
-    ;;
   testnet-india)
     FULLNODE_HOST=node.explorer.india.testnet.hathor.network
     REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
@@ -112,6 +90,16 @@ case $site in
     REACT_APP_NETWORK=mainnet
     S3_BUCKET=hathor-mainnet-public-explorer
     CLOUDFRONT_ID=ETOC9JKCK86OG
+    ;;
+  testnet-shielded-outputs)
+    FULLNODE_HOST=node1.shielded-outputs.testnet.hathor.network
+    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
+    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
+    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.shielded-outputs.testnet.hathor.network/
+    REACT_APP_TIMESERIES_DASHBOARD_ID=afd8c89e-10c6-4fd2-b061-80e6f720dddb
+    REACT_APP_NETWORK=testnet
+    S3_BUCKET=hathor-testnet-shielded-outputs-public-explorer
+    CLOUDFRONT_ID=E2F7GDQQ66DWBW
     ;;
   *)
     echo "Unknown site: $site"

--- a/src/components/tx/TxData.js
+++ b/src/components/tx/TxData.js
@@ -412,12 +412,24 @@ class TxData extends React.Component {
     };
 
     const renderInputs = inputs => {
-      const obj = inputs.map(input => (
-        <div key={`${input.tx_id}${input.index}`}>
-          <Link to={`/transaction/${input.tx_id}`}>{helpers.getShortHash(input.tx_id)}</Link> (
-          {input.index}){renderInputOrOutput(input, 0, false)}
-        </div>
-      ));
+      const obj = inputs.map((input, idx) => {
+        if (input.type === 'shielded') {
+          return (
+            <div key={`shielded-input-${idx}`}>
+              <div className="fw-bold">
+                <i className="fa fa-lock me-1" />
+                <span className="fst-italic">Confidential</span>
+              </div>
+            </div>
+          );
+        }
+        return (
+          <div key={`${input.tx_id}${input.index}`}>
+            <Link to={`/transaction/${input.tx_id}`}>{helpers.getShortHash(input.tx_id)}</Link> (
+            {input.index}){renderInputOrOutput(input, 0, false)}
+          </div>
+        );
+      });
       return renderListWithSpacer(obj);
     };
 
@@ -480,6 +492,35 @@ class TxData extends React.Component {
     const renderOutputs = outputs => {
       const mappedOutputs = outputs.map(o => ({ ...o, value: BigInt(o.value) }));
       const obj = mappedOutputs.map((output, idx) => renderInputOrOutput(output, idx, true));
+      return renderListWithSpacer(obj);
+    };
+
+    const renderShieldedOutputs = shieldedOutputs => {
+      const obj = shieldedOutputs.map((output, idx) => {
+        const decoded = output.decoded || {};
+        // Amount-shielded outputs expose the recipient address in plaintext
+        // via decoded.address (only the amount is hidden). The fullnode does
+        // not populate decoded.type for shielded outputs, so we can't reuse
+        // renderP2PKHorMultiSig as-is — and the raw `script` field is opaque
+        // binary that would render as gibberish if piped through the
+        // transparent-output path. Fully-shielded outputs omit address too.
+        return (
+          <div key={`shielded-${idx}`}>
+            <div className="fw-bold">
+              <i className="fa fa-lock me-1" />
+              <span className="fst-italic">Confidential</span>
+            </div>
+            {decoded.address && (
+              <div>
+                {decoded.address}
+                {decoded.timelock
+                  ? ` | Locked until ${dateFormatter.parseTimestamp(decoded.timelock)}`
+                  : ''}
+              </div>
+            )}
+          </div>
+        );
+      });
       return renderListWithSpacer(obj);
     };
 
@@ -1236,8 +1277,14 @@ class TxData extends React.Component {
               <DropDetails startOpen title={`Inputs (${this.props.transaction.inputs.length})`}>
                 {renderInputs(this.props.transaction.inputs)}
               </DropDetails>
-              <DropDetails startOpen title={`Outputs (${this.props.transaction.outputs.length})`}>
+              <DropDetails
+                startOpen
+                title={`Outputs (${this.props.transaction.outputs.length +
+                  (this.props.transaction.shielded_outputs?.length || 0)})`}
+              >
                 {renderOutputs(this.props.transaction.outputs)}
+                {this.props.transaction.shielded_outputs?.length > 0 &&
+                  renderShieldedOutputs(this.props.transaction.shielded_outputs)}
               </DropDetails>
             </div>
             {this.state.tokens.length > 0 && renderTokenList()}


### PR DESCRIPTION
## Summary

Sets up the `testnet-shielded-outputs` network in the Explorer deployment configuration.

## Changes

**Added**
- New `testnet-shielded-outputs` case in `scripts/deploy.sh` pointing to `node1.shielded-outputs.testnet.hathor.network`
- New `deploy-testnet-shielded-outputs-explorer` GitHub Actions job in `.github/workflows/deploy.yml`

**Removed**
- Deprecated `testnet` (golf) deployment configuration
- Deprecated `testnet-hotel` (hotel) deployment configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI displays shielded outputs as "Confidential" rows, includes them in outputs count, and shows recipient/timelock when available.

* **Chores**
  * Deployment pipeline updated: removed two testnet explorer deployments and added a testnet-shielded-outputs deployment; deploy script adjusted.
  * Build/config updates to avoid bundling Node-only crypto and dependency updates for wallet and Sass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->