### PR TITLE
chore(deps): upgrade wallet-lib to 2.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.26.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@hathor/wallet-lib": "2.12.0",
+        "@hathor/wallet-lib": "2.17.0",
         "@reduxjs/toolkit": "2.5.1",
         "@unleash/proxy-client-react": "1.0.4",
         "axios": "1.8.2",
@@ -2672,9 +2672,9 @@
       }
     },
     "node_modules/@hathor/wallet-lib": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-2.12.0.tgz",
-      "integrity": "sha512-w+BlUFxURAc/t/iTfP3+5DUChHhvPPCR4vW8keKLnnKBUcKfmtpMKfIezt3P2LtknbHUibWxxxEufcw6q/qYOQ==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-2.17.0.tgz",
+      "integrity": "sha512-PhPkv3kCPWX0gXrJTVlA50GfY64kGPmNxqy0XmOuA77tLm2TzvkZTuho/IlPYoaACQZLV2aXGTCJPqTq9eGtMQ==",
       "license": "MIT",
       "dependencies": {
         "axios": "1.7.7",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@hathor/wallet-lib": "2.12.0",
+    "@hathor/wallet-lib": "2.17.0",
     "@reduxjs/toolkit": "2.5.1",
     "@unleash/proxy-client-react": "1.0.4",
     "axios": "1.8.2",


### PR DESCRIPTION
Brings in `CallerId` field support (wallet-lib v2.14.0,), which unblocks the Nano Contract Overview panel for txs whose method args include a CallerId — previously `parseArguments` threw and the panel silently rendered nothing.

### Acceptance Criteria
- Upgrade wallet lib to v2.17.0
- Nano contracts with `CallerId` are correctly shown in the TransactionDetail screen

Production explorer:

<img width="1443" height="829" alt="image" src="https://github.com/user-attachments/assets/93ff18de-f0d9-4fc8-8faa-62efb98042e7" />

Local with fix:

<img width="1344" height="934" alt="image" src="https://github.com/user-attachments/assets/93391370-e014-4b2d-8e41-6631a6b83f84" />

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated wallet library dependency to the latest version for enhanced functionality and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-explorer/pull/515)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->