### PR TITLE
Fix PR preview comment updates

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   cleanup-preview:
@@ -47,14 +48,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          export GH_TOKEN="$GITHUB_TOKEN"
           MARKER="<!-- pr-preview-url -->"
 
           # Find the existing preview comment
-          COMMENT_ID=$(curl -sf \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
-            | jq -r ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+          COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
 
           if [ -z "$COMMENT_ID" ]; then
             echo "No preview comment found, nothing to update."
@@ -66,8 +65,5 @@ jobs:
 
           Preview has been removed as this PR is now closed."
 
-          curl -sf -X PATCH \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
-            -d "$(jq -n --arg body "$BODY" '{"body": $body}')"
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+            --input - <<< "$(jq -n --arg body "$BODY" '{"body": $body}')"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   deploy-preview:
@@ -84,6 +85,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          export GH_TOKEN="$GITHUB_TOKEN"
           MARKER="<!-- pr-preview-url -->"
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           PREVIEW_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${REPO_NAME}/pr-${PR_NUMBER}/"
@@ -99,24 +101,15 @@ jobs:
           > This preview is automatically updated on every push and removed when the PR is closed."
 
           # Find an existing comment that starts with our marker
-          COMMENT_ID=$(curl -sf \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
-            | jq -r ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+          COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
 
           PAYLOAD=$(jq -n --arg body "$BODY" '{"body": $body}')
 
           if [ -n "$COMMENT_ID" ]; then
-            curl -sf -X PATCH \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
-              -d "$PAYLOAD"
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+              --input - <<< "$PAYLOAD"
           else
-            curl -sf -X POST \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              -d "$PAYLOAD"
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --input - <<< "$PAYLOAD"
           fi


### PR DESCRIPTION
## Summary
Fix the PR preview workflows so preview comments are updated reliably instead of failing with exit code 22.

## Changes
- add `pull-requests: write` to the preview and cleanup workflows
- switch PR comment reads and writes from raw `curl` calls to `gh api`
- export `GH_TOKEN` so the GitHub CLI uses the workflow token consistently

## Validation
- checked both edited workflow files for diagnostics
- ran `git diff --check` on the touched workflows

This mirrors the same proven fix already applied in `hathordice-dapp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows that manage pull request previews to grant permission to update PRs.
  * Switched preview comment creation/update to use the GitHub CLI with a token for more reliable comment handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-explorer/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->