### PR TITLE
feat(address): surface shielded output activity on the address screen

### DIFF
--- a/src/components/AddressConfidentialBanner.js
+++ b/src/components/AddressConfidentialBanner.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { ShieldIcon } from './ConfidentialBadge';
+
+/**
+ * Page-level banner shown above the address summary when the address has
+ * confidential (shielded) activity. Copy mirrors the CTX Figma.
+ */
+function AddressConfidentialBanner() {
+  return (
+    <div className="address-confidential-banner" role="note">
+      <ShieldIcon className="address-confidential-banner__icon" />
+      <div className="address-confidential-banner__text">
+        <div className="address-confidential-banner__title">
+          This address has confidential activity
+        </div>
+        <div className="address-confidential-banner__subtitle">
+          Only public balances and tokens are displayed below. Additional confidential amounts exist
+          on this address.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AddressConfidentialBanner;

--- a/src/components/AddressDetailExplorer.js
+++ b/src/components/AddressDetailExplorer.js
@@ -12,6 +12,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useIsMobile } from '../hooks';
 import AddressSummary from './AddressSummary';
 import AddressHistory from './AddressHistory';
+import AddressConfidentialBanner from './AddressConfidentialBanner';
 import Loading from './Loading';
 import ErrorMessageWithIcon from './error/ErrorMessageWithIcon';
 import PaginationURL from '../utils/pagination';
@@ -35,7 +36,7 @@ import helpers from '../utils/helpers';
  * @return {boolean} True if should update the list, false otherwise
  */
 function shouldUpdate(tx, checkToken, queryToken, updateAddress) {
-  const arr = [...tx.outputs, ...tx.inputs];
+  const arr = [...tx.outputs, ...(tx.shielded_outputs || []), ...tx.inputs];
 
   for (const element of arr) {
     if (element?.decoded?.address === updateAddress) {
@@ -96,6 +97,7 @@ function AddressDetailExplorer() {
   const [errorMessage, setErrorMessage] = useState('');
   const [warningRefreshPage, setWarningRefreshPage] = useState(false);
   const [warnMissingTokens, setWarnMissingTokens] = useState(0);
+  const [hasConfidentialActivity, setHasConfidentialActivity] = useState(false);
   const [selectedTokenMetadata, setSelectedTokenMetadata] = useState(null);
   const [metadataLoaded, setMetadataLoaded] = useState(false);
   const [addressTokens, setAddressTokens] = useState({});
@@ -283,6 +285,7 @@ function AddressDetailExplorer() {
 
         const tokens = tokensResponse.tokens || {};
         const total = tokensResponse.total || 0;
+        setHasConfidentialActivity(Boolean(tokensResponse.has_confidential_activity));
 
         if (total > Object.keys(tokens).length) {
           // There were unfetched tokens
@@ -342,6 +345,7 @@ function AddressDetailExplorer() {
     setTransactions([]);
     setBalance({});
     setErrorMessage('');
+    setHasConfidentialActivity(false);
 
     // User may already have a token selected on the URL
     const refQueryParams = pagination.current.obtainQueryParams();
@@ -569,6 +573,7 @@ function AddressDetailExplorer() {
       <div>
         {renderWarningAlert()}
         {renderMissingTokensAlert()}
+        {hasConfidentialActivity && <AddressConfidentialBanner />}
         <AddressSummary
           address={address}
           tokens={addressTokens}
@@ -577,6 +582,7 @@ function AddressDetailExplorer() {
           tokenSelectChanged={onTokenSelectChanged}
           isNFT={isNFT()}
           metadataLoaded={metadataLoaded}
+          hasConfidentialActivity={hasConfidentialActivity}
         />
         <AddressHistory
           address={address}

--- a/src/components/AddressHistory.js
+++ b/src/components/AddressHistory.js
@@ -16,6 +16,8 @@ import EllipsiCell from './EllipsiCell';
 import { ReactComponent as RowBottomIcon } from '../assets/images/leading-icon.svg';
 import { ReactComponent as RowTopIcon } from '../assets/images/leading-top-icon.svg';
 import { COLORS } from '../constants';
+import ConfidentialBadge from './ConfidentialBadge';
+import { txHasConfidentialForAddress, describeAddressValue } from '../utils/shieldedOutputs';
 
 const mapStateToProps = state => ({
   decimalPlaces: state.serverInfo.decimal_places,
@@ -78,6 +80,47 @@ class AddressHistory extends SortableTable {
     );
   }
 
+  /**
+   * Render the Value column for a row. When the tx carries confidential
+   * (shielded) outputs/inputs for this address, append a "Confidential" badge
+   * (or show it alone when there is no public value for the selected token).
+   */
+  renderValueContent(tx, prettyValue) {
+    const hasConfidential = txHasConfidentialForAddress(
+      this.props.txCache[tx.tx_id],
+      this.props.address
+    );
+    const descriptor = describeAddressValue({
+      balance: tx.balance,
+      hasConfidential,
+    });
+
+    const valueSpan = (
+      <span style={{ color: tx.balance < 0 ? COLORS.danger : COLORS.success }}>{prettyValue}</span>
+    );
+
+    if (descriptor === 'confidential-only') {
+      return (
+        <span className="confidential-value">
+          <ConfidentialBadge />
+        </span>
+      );
+    }
+
+    if (descriptor === 'value-and-confidential') {
+      return (
+        <>
+          {valueSpan}
+          <div className="confidential-value">
+            + <ConfidentialBadge />
+          </div>
+        </>
+      );
+    }
+
+    return valueSpan;
+  }
+
   renderNewTableBodyUi(isMobile) {
     const ellipsisCount = isMobile ? 4 : 12;
     return this.props.data.map(tx => {
@@ -136,11 +179,7 @@ class AddressHistory extends SortableTable {
             {dateFormatter.parseTimestampNewUi(tx.timestamp)}
           </td>
           <td className="state td-mobile">{statusElement}</td>
-          <td className="value td-mobile">
-            <span style={{ color: tx.balance < 0 ? COLORS.danger : COLORS.success }}>
-              {prettyValue}
-            </span>
-          </td>
+          <td className="value td-mobile">{this.renderValueContent(tx, prettyValue)}</td>
         </tr>
       );
     });

--- a/src/components/AddressSummary.js
+++ b/src/components/AddressSummary.js
@@ -30,6 +30,10 @@ class AddressSummary extends React.Component {
       return null;
     }
 
+    // Confidential activity means the indexer only sees public values; label
+    // the public-only fields so the number isn't mistaken for the full amount.
+    const publicLabel = name => (this.props.hasConfidentialActivity ? `${name} (public)` : name);
+
     const newLoadMainInfo = () => {
       return (
         <div className="summary-main-info alter-background">
@@ -39,7 +43,7 @@ class AddressSummary extends React.Component {
           </div>
           <div className="summary-main-info-container">
             <div className="address-container-title summary-container-title-purple">
-              Number of tokens
+              {publicLabel('Number of tokens')}
             </div>
             <div>{Object.keys(this.props.tokens).length}</div>
           </div>
@@ -85,15 +89,15 @@ class AddressSummary extends React.Component {
             <div>{renderType()}</div>
           </div>
           <div className="summary-balance-info-container">
-            <div className="address-container-title">Number of transactions</div>
+            <div className="address-container-title">{publicLabel('Number of transactions')}</div>
             <div>{this.props.balance.transactions}</div>
           </div>
           <div className="summary-balance-info-container">
-            <div className="address-container-title">Total received</div>
+            <div className="address-container-title">{publicLabel('Total received')}</div>
             <div>{renderValue(this.props.balance.total_received)}</div>
           </div>
           <div className="summary-balance-info-container">
-            <div className="address-container-title">Total spent</div>
+            <div className="address-container-title">{publicLabel('Total spent')}</div>
             <div>
               {renderValue(
                 this.props.balance.total_received -
@@ -103,7 +107,7 @@ class AddressSummary extends React.Component {
             </div>
           </div>
           <div className="summary-balance-info-container">
-            <div className="address-container-title">Unlocked balance</div>
+            <div className="address-container-title">{publicLabel('Unlocked balance')}</div>
             <div>{renderValue(this.props.balance.unlocked_balance)}</div>
           </div>
           <div className="summary-balance-info-container">
@@ -183,6 +187,11 @@ AddressSummary.propTypes = {
   balance: PropTypes.object.isRequired,
   selectedToken: PropTypes.string.isRequired,
   tokenSelectChanged: PropTypes.func.isRequired,
+  hasConfidentialActivity: PropTypes.bool,
+};
+
+AddressSummary.defaultProps = {
+  hasConfidentialActivity: false,
 };
 
 export default connect(mapStateToProps)(AddressSummary);

--- a/src/components/ConfidentialBadge.js
+++ b/src/components/ConfidentialBadge.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Shield-with-padlock glyph used to mark confidential (shielded) data.
+ * Mirrors the inline icon in tx/TxData.js (#514) so the transaction and
+ * address screens share the same iconography.
+ */
+export function ShieldIcon({ className }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M6.6795 10.5514H9.3205C9.49128 10.5514 9.63439 10.4936 9.74983 10.378C9.86528 10.2626 9.923 10.1195 9.923 9.94871V7.97437C9.923 7.80371 9.86528 7.6606 9.74983 7.54504C9.63439 7.4296 9.49128 7.37187 9.3205 7.37187H9.26283V6.70521C9.26283 6.35565 9.14083 6.05887 8.89683 5.81487C8.65283 5.57076 8.356 5.44871 8.00633 5.44871C7.65678 5.44871 7.36 5.57076 7.116 5.81487C6.872 6.05887 6.75 6.35565 6.75 6.70521V7.37187H6.6795C6.50872 7.37187 6.36561 7.4296 6.25017 7.54504C6.13472 7.6606 6.077 7.80371 6.077 7.97437V9.94871C6.077 10.1195 6.13472 10.2626 6.25017 10.378C6.36561 10.4936 6.50872 10.5514 6.6795 10.5514ZM7.33967 7.37187V6.70521C7.33967 6.51632 7.40356 6.35799 7.53133 6.23021C7.65911 6.10243 7.81744 6.03854 8.00633 6.03854C8.19522 6.03854 8.35356 6.10243 8.48133 6.23021C8.60911 6.35799 8.673 6.51632 8.673 6.70521V7.37187H7.33967ZM7.79617 14.2307C7.7295 14.2196 7.66494 14.2029 7.6025 14.1807C6.19661 13.6807 5.07806 12.7942 4.24683 11.5212C3.41561 10.2481 3 8.87437 3 7.40004V4.39754C3 4.14432 3.07283 3.91637 3.2185 3.71371C3.36406 3.51115 3.55233 3.36432 3.78333 3.27321L7.57817 1.85654C7.72094 1.80521 7.86156 1.77954 8 1.77954C8.13844 1.77954 8.27906 1.80521 8.42183 1.85654L12.2167 3.27321C12.4477 3.36432 12.6359 3.51115 12.7815 3.71371C12.9272 3.91637 13 4.14432 13 4.39754V7.40004C13 8.87437 12.5844 10.2481 11.7532 11.5212C10.9219 12.7942 9.80339 13.6807 8.3975 14.1807C8.33506 14.2029 8.2705 14.2196 8.20383 14.2307C8.13717 14.2418 8.06922 14.2474 8 14.2474C7.93078 14.2474 7.86283 14.2418 7.79617 14.2307ZM8 13.2667C9.15556 12.9 10.1111 12.1667 10.8667 11.0667C11.6222 9.96671 12 8.74449 12 7.40004V4.39104C12 4.34837 11.9882 4.30993 11.9647 4.27571C11.9412 4.24148 11.9081 4.21582 11.8653 4.19871L8.0705 2.78204C8.04917 2.77348 8.02567 2.76921 8 2.76921C7.97433 2.76921 7.95083 2.77348 7.9295 2.78204L4.13467 4.19871C4.09189 4.21582 4.05878 4.24148 4.03533 4.27571C4.01178 4.30993 4 4.34837 4 4.39104V7.40004C4 8.74449 4.37778 9.96671 5.13333 11.0667C5.88889 12.1667 6.84444 12.9 8 13.2667Z"
+        fill="#B7BFC7"
+      />
+    </svg>
+  );
+}
+
+ShieldIcon.propTypes = {
+  className: PropTypes.string,
+};
+
+ShieldIcon.defaultProps = {
+  className: 'me-1',
+};
+
+/**
+ * Inline "Confidential" badge. With `tokenSymbol` (AmountShielded) it reads
+ * "Confidential amount · <SYMBOL>"; otherwise just "Confidential".
+ */
+function ConfidentialBadge({ tokenSymbol }) {
+  return (
+    <span className="fw-bold d-inline-flex align-items-center">
+      <ShieldIcon />
+      {tokenSymbol ? (
+        <>
+          <span className="fst-italic">Confidential amount</span>
+          <span className="mx-2">·</span>
+          <span>{tokenSymbol}</span>
+        </>
+      ) : (
+        <span className="fst-italic">Confidential</span>
+      )}
+    </span>
+  );
+}
+
+ConfidentialBadge.propTypes = {
+  tokenSymbol: PropTypes.string,
+};
+
+ConfidentialBadge.defaultProps = {
+  tokenSymbol: undefined,
+};
+
+export default ConfidentialBadge;

--- a/src/newUi.scss
+++ b/src/newUi.scss
@@ -4258,3 +4258,34 @@ th.sortable {
   color: var(--purple-text);
   filter: brightness(1.1);
 }
+
+.address-confidential-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 24px;
+  margin-bottom: 16px;
+  border-radius: 8px;
+  background-color: var(--background-focus);
+
+  &__icon {
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+
+  &__title {
+    font-weight: 700;
+    color: var(--text-focus);
+  }
+
+  &__subtitle {
+    font-size: 14px;
+    opacity: 0.8;
+  }
+}
+
+.confidential-value {
+  font-size: 14px;
+  color: var(--text-focus);
+  opacity: 0.7;
+}

--- a/src/utils/shieldedOutputs.js
+++ b/src/utils/shieldedOutputs.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pure helpers to detect confidential (shielded) activity in a full-node
+ * transaction, used by the address screen. No @hathor/wallet-lib import on
+ * purpose: keeps these unit-testable under the CRA jest config (which does
+ * not transform wallet-lib's ESM).
+ *
+ * Shielded outputs live in a separate `shielded_outputs[]` array (not in
+ * `outputs[]`); a shielded input is a regular input flagged
+ * `type === 'shielded'`. The recipient `decoded.address` is public in both.
+ */
+
+/**
+ * True when the transaction carries any shielded output or shielded input
+ * whose decoded address matches `address`.
+ *
+ * @param {Object} [tx] Full-node transaction (from txCache)
+ * @param {string} address Address being viewed
+ * @returns {boolean}
+ */
+export function txHasConfidentialForAddress(tx, address) {
+  if (!tx) {
+    return false;
+  }
+
+  const shieldedOutputs = tx.shielded_outputs || [];
+  for (const output of shieldedOutputs) {
+    if (output?.decoded?.address === address) {
+      return true;
+    }
+  }
+
+  const inputs = tx.inputs || [];
+  for (const input of inputs) {
+    if (input?.type === 'shielded' && input?.decoded?.address === address) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Classify how the address-history Value column should render a row.
+ *
+ * @param {Object} params
+ * @param {number} params.balance Public net balance for the selected token
+ * @param {boolean} params.hasConfidential Whether the tx has confidential
+ *   activity for this address
+ * @returns {'confidential-only'|'value-and-confidential'|'value-only'}
+ */
+export function describeAddressValue({ balance, hasConfidential }) {
+  if (!hasConfidential) {
+    return 'value-only';
+  }
+  if (balance === 0) {
+    return 'confidential-only';
+  }
+  return 'value-and-confidential';
+}

--- a/src/utils/shieldedOutputs.test.js
+++ b/src/utils/shieldedOutputs.test.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { txHasConfidentialForAddress, describeAddressValue } from './shieldedOutputs';
+
+const ADDR = 'HR7JvXSbg8mdvXopKtc97C64NR4TZmQE3T';
+
+describe('txHasConfidentialForAddress', () => {
+  it('returns false for an undefined tx', () => {
+    expect(txHasConfidentialForAddress(undefined, ADDR)).toBe(false);
+  });
+
+  it('returns false when there are no shielded outputs or inputs', () => {
+    const tx = { outputs: [{ decoded: { address: ADDR } }], inputs: [] };
+    expect(txHasConfidentialForAddress(tx, ADDR)).toBe(false);
+  });
+
+  it('detects a shielded output for the address', () => {
+    const tx = { shielded_outputs: [{ commitment: 'aa', decoded: { address: ADDR } }] };
+    expect(txHasConfidentialForAddress(tx, ADDR)).toBe(true);
+  });
+
+  it('ignores a shielded output for a different address', () => {
+    const tx = { shielded_outputs: [{ commitment: 'aa', decoded: { address: 'OTHER' } }] };
+    expect(txHasConfidentialForAddress(tx, ADDR)).toBe(false);
+  });
+
+  it('detects a shielded input for the address', () => {
+    const tx = { inputs: [{ type: 'shielded', decoded: { address: ADDR } }] };
+    expect(txHasConfidentialForAddress(tx, ADDR)).toBe(true);
+  });
+
+  it('ignores a transparent input for the address', () => {
+    const tx = { inputs: [{ type: 'p2pkh', decoded: { address: ADDR } }] };
+    expect(txHasConfidentialForAddress(tx, ADDR)).toBe(false);
+  });
+});
+
+describe('describeAddressValue', () => {
+  it('returns value-only when there is no confidential activity', () => {
+    expect(describeAddressValue({ balance: 100, hasConfidential: false })).toBe('value-only');
+  });
+
+  it('returns confidential-only when confidential and the public balance is zero', () => {
+    expect(describeAddressValue({ balance: 0, hasConfidential: true })).toBe('confidential-only');
+  });
+
+  it('returns value-and-confidential when confidential and the public balance is non-zero', () => {
+    expect(describeAddressValue({ balance: 120, hasConfidential: true })).toBe(
+      'value-and-confidential'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Extends the explorer address screen (`/address/:address`) to surface confidential (shielded) output activity, building on top of #514 (the tx-detail shielded work). Three UI elements (Figma CTX node `804-10475`):

1. **Banner** — a page-level "This address has confidential activity" notice, shown when the explorer-service flag `has_confidential_activity` is `true`.
2. **`(public)` labels** on the public-only summary fields (Number of tokens, Number of transactions, Total received, Total spent, Unlocked balance — **not** Locked balance), conditional on confidential activity.
3. **Per-transaction "Confidential" indicator** in the history Value column: `🛡 Confidential` alone for a confidential-only tx, or the public value + `+ 🛡 Confidential` for a mixed tx. Derived client-side from `shielded_outputs[]` in `txCache`.

## How it works

- **Per-tx detection** is client-side, from the full-node tx already in `txCache` (a shielded output lives in `shielded_outputs[]`; a shielded input is flagged `type === 'shielded'`; the recipient `decoded.address` is public). New pure helpers in `src/utils/shieldedOutputs.js` (unit-tested) avoid importing `@hathor/wallet-lib` so they run under the CRA jest config.
- **The page-level banner** uses a backend flag so it stays accurate across history pagination, from a new gracefully-degrading explorer-service query on `/address/tokens` (companion PR in `hathor-explorer-service`).
- **Summary values are public-only by construction** — the wallet-service indexer has no scan keys for arbitrary addresses, so `(public)` is permanently correct (pure relabeling).
- `shouldUpdate` now also scans `shielded_outputs`, so a new confidential tx for the address still triggers the refresh warning.

No Unleash flag — activation is data-driven, consistent with #514. Degrades gracefully before the wallet-service shielded stack (#439–#447) deploys: mixed txs still show `+ Confidential` from `txCache`; the banner and confidential-only rows light up automatically once the backend ships.

## Files

- **New:** `src/utils/shieldedOutputs.js` (+ test), `src/components/ConfidentialBadge.js` (`ShieldIcon` + badge), `src/components/AddressConfidentialBanner.js`
- **Modified:** `AddressSummary.js` (`(public)` labels), `AddressHistory.js` (Value-column rendering), `AddressDetailExplorer.js` (plumb flag + banner + `shouldUpdate`), `src/newUi.scss`

## Backend dependency

The banner/labels activate via `has_confidential_activity` on the `/address/tokens` response, added in a companion `hathor-explorer-service` PR (`feat/address-confidential-activity-flag`). It reads `tx_output.mode != 0` with graceful fallback to `false` when the `mode` column isn't deployed yet.

## Testing

- Jest: 16/16 (`shieldedOutputs.test.js` 9/9 + existing `unblinding.test.js` 7/7).
- `npm run build` passes; eslint clean on all source files.
- Manual smoke test via the real UI (Playwright + mocked backend) verified both the confidential render (banner + 5 `(public)` labels + `Confidential` badges) and graceful degradation (normal address unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)