### PR TITLE
test(e2e): add Playwright navigation-smoke suite against mainnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ yarn-error.log*
 
 *.swp
 *.swo
+
+# e2e (Playwright)
+/playwright-report
+/test-results
+/reports/screenshots

--- a/docs/superpowers/plans/2026-06-16-explorer-e2e-navigation-smoke.md
+++ b/docs/superpowers/plans/2026-06-16-explorer-e2e-navigation-smoke.md
@@ -1,0 +1,801 @@
+# Explorer E2E — Infrastructure & Navigation Smoke Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **⚠️ GIT POLICY (user override):** This user FORBIDS the agent from running `git add`,
+> `git commit`, or `git stash`. Every "Commit" step below shows the command for the **user to
+> run manually**. At each commit checkpoint, STOP and ask the user to run it — never run it
+> yourself.
+
+**Goal:** Stand up a Playwright E2E suite for hathor-explorer (config, fixture, page objects,
+conventions doc, anchors) and ship a navigation-smoke journey that asserts every main route
+renders its identifying content with no global error, against real public mainnet backends.
+
+**Architecture:** Playwright boots the explorer's own CRA dev server locally (`webServer`),
+pointed at real public **mainnet** backends via `webServer.env` (OS env wins over the
+committed `.env.local`). The app is read-only and stateless → `fullyParallel: true`. Tests
+are TypeScript under their own scoped tsconfig, isolated from the JS app build. Three layers:
+page objects (UI-decoupled, screen-scoped) → a page-scoped fixture → specs.
+
+**Tech Stack:** Playwright Test (`@playwright/test`), TypeScript, Chromium. App under test:
+React 18 / CRA (`react-app-rewired`).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `playwright.e2e.config.ts` (repo root) | Playwright config: `webServer` (local explorer, mainnet env), `baseURL`, reporters, `fullyParallel`, screenshot/trace/video, desktop viewport. |
+| `tests/e2e/tsconfig.json` | Scoped TS config for the suite. **Must NOT be at repo root** (a root `tsconfig.json` flips CRA into TypeScript mode and breaks `npm start`). |
+| `tests/e2e/e2e.md` | Conventions doc — read before reading/writing any test. |
+| `tests/e2e/support/anchors.ts` | Immutable on-chain anchors mirrored from `src/constants.js` (genesis ids, HTR uid). Unused by smoke; ready for future detail-page journeys. |
+| `tests/e2e/pages/ExplorerApp.ts` | App-shell page object: navigate, assert no global error/blocked state, capture evidence screenshot. |
+| `tests/e2e/pages/NavigationBar.ts` | Top-nav page object: brand/links present, network label, click a top-level link. |
+| `tests/e2e/pages/routes.ts` | `SMOKE_ROUTES` registry: route → identifying locator. Parameterizes the smoke spec. |
+| `tests/e2e/fixtures/explorer-fixture.ts` | Page-scoped fixture exposing `app` (ExplorerApp) + `nav` (NavigationBar). |
+| `tests/e2e/navigation-smoke.spec.ts` | The v1 journey: per-route render check + screenshot, nav-click navigation, footer. |
+| `package.json` | + devDeps (`@playwright/test`, `typescript`, `@types/node`) + scripts (`e2e`, `e2e:headed`, `e2e:ui`). |
+| `.gitignore` | + `playwright-report/`, `test-results/`, `reports/screenshots/`. |
+
+---
+
+## Task 1: Tooling — install Playwright, scripts, gitignore
+
+**Files:**
+- Modify: `package.json` (devDependencies + scripts)
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Install Playwright test + TypeScript dev deps**
+
+Run:
+```bash
+npm install --save-dev @playwright/test@1.50.1 typescript@5.7.3 @types/node@22.13.1
+```
+Expected: installs without error; `package.json` `devDependencies` gains the three packages.
+(Pin to these versions; adjust only if npm reports an incompatibility.)
+
+- [ ] **Step 2: Install the Chromium browser binary**
+
+Run:
+```bash
+npx playwright install chromium
+```
+Expected: downloads the Chromium build Playwright uses (prints "chromium ... downloaded").
+
+- [ ] **Step 3: Add E2E npm scripts**
+
+In `package.json`, add to `"scripts"` (after the existing `"format:check"` line):
+```json
+    "e2e": "playwright test --config playwright.e2e.config.ts",
+    "e2e:headed": "playwright test --config playwright.e2e.config.ts --headed",
+    "e2e:ui": "playwright test --config playwright.e2e.config.ts --ui",
+```
+
+- [ ] **Step 4: Update `.gitignore`**
+
+Append to `.gitignore`:
+```gitignore
+
+# e2e (Playwright)
+/playwright-report
+/test-results
+/reports/screenshots
+```
+
+- [ ] **Step 5: Verify CRA is still in JS mode (no root tsconfig was created)**
+
+Run:
+```bash
+ls tsconfig.json 2>/dev/null && echo "ROOT TSCONFIG EXISTS - BAD" || echo "no root tsconfig - good"
+```
+Expected: `no root tsconfig - good`. If a root `tsconfig.json` exists, delete it — CRA would
+otherwise switch to TypeScript mode and `npm start` would fail. (Our scoped config lives at
+`tests/e2e/tsconfig.json`, created in Task 2.)
+
+- [ ] **Step 6: Commit (user runs manually)**
+
+```bash
+git add package.json package-lock.json .gitignore
+git commit -m "chore(e2e): add Playwright tooling, scripts and gitignore entries"
+```
+
+---
+
+## Task 2: Scoped TypeScript config for the suite
+
+**Files:**
+- Create: `tests/e2e/tsconfig.json`
+
+- [ ] **Step 1: Create `tests/e2e/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2021", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../playwright.e2e.config.ts"]
+}
+```
+
+- [ ] **Step 2: Verify it is NOT at repo root**
+
+Run:
+```bash
+test -f tests/e2e/tsconfig.json && test ! -f tsconfig.json && echo OK || echo WRONG-LOCATION
+```
+Expected: `OK`.
+
+- [ ] **Step 3: Commit (user runs manually)**
+
+```bash
+git add tests/e2e/tsconfig.json
+git commit -m "chore(e2e): add scoped tsconfig for the Playwright suite"
+```
+
+---
+
+## Task 3: Playwright config (webServer + mainnet env)
+
+**Files:**
+- Create: `playwright.e2e.config.ts`
+
+- [ ] **Step 1: Create `playwright.e2e.config.ts`**
+
+```ts
+import { defineConfig } from '@playwright/test';
+
+/**
+ * E2E suite for hathor-explorer. Playwright boots the app's own CRA dev server locally and
+ * points it at the REAL public mainnet backends. The explorer is read-only and stateless, so
+ * tests run fully parallel.
+ *
+ * Env override: `webServer.env` sets OS-level env for the spawned dev server. CRA's dotenv
+ * loader does NOT override variables already present in process.env, so these win over the
+ * committed `.env.local` (which targets the localnet docker).
+ */
+const PORT = 3002;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  tsconfig: './tests/e2e/tsconfig.json',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  // Real public backends can be slow; be generous.
+  timeout: 60_000,
+  expect: { timeout: 20_000 },
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: BASE_URL,
+    viewport: { width: 1366, height: 900 }, // desktop: top-nav links are visible (not mobile burger)
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    // `npm start` (not `start-js`) so the SCSS is compiled+watched alongside the dev server —
+    // `start-js` alone skips CSS, which can make styled elements read as hidden in Playwright.
+    command: 'npm start',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      BROWSER: 'none', // don't auto-open a browser tab
+      PORT: String(PORT),
+      REACT_APP_BASE_URL: 'https://node.explorer.hathor.network/v1a/',
+      REACT_APP_EXPLORER_SERVICE_BASE_URL: 'https://explorer-service.hathor.network/',
+      REACT_APP_WS_URL: 'wss://node.explorer.hathor.network/v1a/ws/',
+      REACT_APP_NETWORK: 'mainnet',
+      REACT_APP_EXPLORER_MODE: 'full',
+      // no SKIP_FEATURE_TOGGLE -> real Unleash
+    },
+  },
+});
+```
+
+- [ ] **Step 2: Verify the config loads and lists zero tests (none written yet)**
+
+Run:
+```bash
+npx playwright test --config playwright.e2e.config.ts --list
+```
+Expected: command exits cleanly reporting `Total: 0 tests in 0 files` (config parsed; no specs
+yet). It must NOT error on the config itself.
+
+- [ ] **Step 3: Commit (user runs manually)**
+
+```bash
+git add playwright.e2e.config.ts
+git commit -m "chore(e2e): add Playwright config booting the explorer against mainnet"
+```
+
+---
+
+## Task 4: Conventions doc + immutable anchors
+
+**Files:**
+- Create: `tests/e2e/e2e.md`
+- Create: `tests/e2e/support/anchors.ts`
+
+- [ ] **Step 1: Create `tests/e2e/e2e.md`**
+
+```markdown
+# Explorer E2E — Architecture & Conventions
+
+**Read this before reading or writing any test in `tests/e2e/`.**
+
+These tests drive the **real explorer UI** against **real public mainnet backends**
+(`node.explorer.hathor.network` + `explorer-service.hathor.network`) with **real Unleash**
+feature flags. Unlike the wallet, the explorer is **read-only**: no wallet, nothing to sign,
+no extension, no per-test state. The suite is therefore simpler than the wallet's and runs
+fully parallel.
+
+## The rules that matter most
+
+1. **Drive the real explorer against real public backends. Use real Unleash — never skip it.**
+   The dev server runs WITHOUT `SKIP_FEATURE_TOGGLE`; flag-gated UI must resolve from the real
+   proxy. Flags are per-network (`explorer-tokens-mainnet`, ...).
+2. **Assert only what the UI actually renders — verify against the real component first.**
+   Never assume a heading/value is present; read the screen's component (e.g. `src/screens/*`)
+   or inspect the live DOM, then assert.
+3. **Always wait past the version gate.** `App.js` shows `<Loading/>` until
+   `versionApi.getVersion()` resolves, and `<VersionError/>` if the node version is too old.
+   A per-route heading assertion (with a generous timeout) inherently waits past this.
+4. **Page objects are decoupled and screen-scoped.** They expose intent-level verbs
+   (`goto`, `expectLoaded`, `clickTopLink`), never raw selectors to the spec.
+5. **Tests are independent and parallel** (read-only app, no shared state). Never rely on
+   ordering or on another test's effect.
+6. **Immutable chain data lives in `support/anchors.ts`**, mirroring `src/constants.js`.
+
+## Layering
+
+| Layer | File | Job |
+|-------|------|-----|
+| Page object | `pages/*.ts` | Granular UI steps for one screen/region. |
+| Fixture | `fixtures/explorer-fixture.ts` | Exposes `app` (ExplorerApp) + `nav` (NavigationBar) on a fresh page. |
+| Spec | `*.spec.ts` | The scenario: navigate + assert. |
+
+## Global error / blocked states (what "no error" means)
+
+- `VersionError`  → text "Please update you API version and try again"
+- `ErrorMessage`  → text "Error loading."
+- ChunkErrorBoundary → text "Failed to load this page"
+
+## File map
+
+```
+tests/e2e/
+  e2e.md                       # this file
+  tsconfig.json                # scoped TS config (NOT at repo root)
+  support/anchors.ts           # immutable on-chain anchors
+  pages/
+    ExplorerApp.ts             # app shell: goto, no-global-error, evidence screenshot
+    NavigationBar.ts           # top nav: brand/links, network label, click link
+    routes.ts                  # SMOKE_ROUTES registry (route -> identifying locator)
+  fixtures/explorer-fixture.ts # app + nav fixtures
+  navigation-smoke.spec.ts     # the v1 journey
+```
+
+> Config (`playwright.e2e.config.ts`) lives at the repo root.
+```
+
+- [ ] **Step 2: Create `tests/e2e/support/anchors.ts`**
+
+```ts
+/**
+ * Immutable on-chain anchors, mirrored from `src/constants.js`. Deterministic detail-page
+ * journeys (future iterations) reference these so specs never hardcode chain data. The
+ * navigation-smoke journey does not use them yet — they are established here for reuse.
+ */
+export const MAINNET_GENESIS_BLOCK = [
+  '000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc',
+] as const;
+
+export const MAINNET_GENESIS_TX = [
+  '0002d4d2a15def7604688e1878ab681142a7b155cbe52a6b4e031250ae96db0a',
+  '0002ad8d1519daaddc8e1a37b14aac0b045129c01832281fb1c02d873c7abbf9',
+] as const;
+
+export const TESTNET_GENESIS_BLOCK = [
+  '0000033139d08176d1051fb3a272c3610457f0c7f686afbe0afe3d37f966db85',
+] as const;
+
+export const TESTNET_GENESIS_TX = [
+  '00e161a6b0bee1781ea9300680913fb76fd0fac4acab527cd9626cc1514abdc9',
+  '00975897028ceb037307327c953f5e7ad4d3f42402d71bd3d11ecb63ac39f01a',
+] as const;
+
+/** Native token (HTR) uid used across the explorer. */
+export const HTR_UID = '00';
+```
+
+- [ ] **Step 3: Commit (user runs manually)**
+
+```bash
+git add tests/e2e/e2e.md tests/e2e/support/anchors.ts
+git commit -m "docs(e2e): add conventions doc and immutable on-chain anchors"
+```
+
+---
+
+## Task 5: Page objects (ExplorerApp, NavigationBar, routes registry)
+
+**Files:**
+- Create: `tests/e2e/pages/ExplorerApp.ts`
+- Create: `tests/e2e/pages/NavigationBar.ts`
+- Create: `tests/e2e/pages/routes.ts`
+
+- [ ] **Step 1: Create `tests/e2e/pages/ExplorerApp.ts`**
+
+```ts
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * App-shell page object. Decoupled from any single screen: it navigates, asserts the absence
+ * of the global error/blocked states, and captures evidence screenshots.
+ */
+export class ExplorerApp {
+  constructor(private readonly page: Page) {}
+
+  /** Navigate to a route (relative to baseURL). */
+  async goto(path: string): Promise<void> {
+    await this.page.goto(path);
+  }
+
+  /**
+   * Assert none of the global blocked states are rendered:
+   *  - VersionError (node version too old)
+   *  - ErrorMessage (initial API load failed)
+   *  - ChunkErrorBoundary fallback (lazy chunk failed to load)
+   * Call this AFTER asserting a screen's identifying element, so the app has settled.
+   */
+  async expectNoGlobalError(): Promise<void> {
+    await expect(
+      this.page.getByText(/please update you api version and try again/i),
+    ).toHaveCount(0);
+    await expect(this.page.getByText(/^error loading\.$/i)).toHaveCount(0);
+    await expect(this.page.getByText(/failed to load this page/i)).toHaveCount(0);
+  }
+
+  /**
+   * Capture a full-page evidence screenshot (no baseline comparison — visual regression is a
+   * future iteration). Playwright creates the parent dirs automatically.
+   */
+  async captureEvidence(name: string): Promise<void> {
+    await this.page.screenshot({ path: `reports/screenshots/${name}.png`, fullPage: true });
+  }
+}
+```
+
+- [ ] **Step 2: Create `tests/e2e/pages/NavigationBar.ts`**
+
+```ts
+import { expect, type Page } from '@playwright/test';
+
+type TopLink = 'Home' | 'Network' | 'Statistics';
+
+/**
+ * Top navigation bar page object. The explorer always renders the "new UI" nav
+ * (`Navigation.renderNewUi`). Home/Network/Statistics are direct NavLinks; Tokens/Tools/Nano
+ * are Bootstrap dropdowns (not exercised by the smoke nav-click check).
+ */
+export class NavigationBar {
+  constructor(private readonly page: Page) {}
+
+  /** The nav is present once the brand logo link is visible. */
+  async expectVisible(): Promise<void> {
+    await expect(this.page.locator('nav a.navbar-brand')).toBeVisible();
+  }
+
+  /**
+   * Assert the network label under the logo. Doubles as verification that the mainnet env
+   * override took effect: the label is rendered straight from REACT_APP_NETWORK.
+   */
+  async expectNetwork(name: string): Promise<void> {
+    await expect(this.page.locator('nav .nav-title')).toHaveText(name);
+  }
+
+  /** Click a top-level (non-dropdown) nav link by its visible text. */
+  async clickTopLink(name: TopLink): Promise<void> {
+    await this.page.getByRole('link', { name, exact: true }).click();
+  }
+}
+```
+
+- [ ] **Step 3: Create `tests/e2e/pages/routes.ts`**
+
+```ts
+import { type Locator, type Page } from '@playwright/test';
+
+/**
+ * A smoke route: its URL, a stable name (test title + screenshot filename), and the locator
+ * for the element that uniquely identifies "this screen rendered". Identifiers are taken from
+ * the real components in `src/screens/*` (verified) — prefer role/heading/text over structure.
+ */
+export interface RouteSpec {
+  name: string;
+  path: string;
+  heading: (page: Page) => Locator;
+}
+
+export const SMOKE_ROUTES: RouteSpec[] = [
+  // DashboardTx — src/screens/DashboardTx.js: <p class="title-page data-title">Live Data</p>
+  { name: 'home', path: '/', heading: p => p.getByText(/^live data$/i) },
+  // TransactionList — <h1 class="title-tx-page">Transactions</h1>
+  {
+    name: 'transactions',
+    path: '/transactions',
+    heading: p => p.getByRole('heading', { name: 'Transactions', exact: true }),
+  },
+  // BlockList — <h1 class="title-tx-page">Blocks</h1>
+  {
+    name: 'blocks',
+    path: '/blocks',
+    heading: p => p.getByRole('heading', { name: 'Blocks', exact: true }),
+  },
+  // TokenList — <p class="title-page">Tokens</p> (Unleash explorer-tokens-mainnet; ON in prod)
+  {
+    name: 'tokens',
+    path: '/tokens',
+    heading: p => p.locator('p.title-page', { hasText: /^Tokens$/ }),
+  },
+  // TokenBalances — <p class="title-page">Token Balance</p> (Unleash explorer-address-list-mainnet)
+  {
+    name: 'token-balances',
+    path: '/token_balances',
+    heading: p => p.locator('p.title-page', { hasText: /token balance/i }),
+  },
+  // Dashboard (statistics) — <h2 class="statistics-title">Statistics</h2>
+  {
+    name: 'statistics',
+    path: '/statistics',
+    heading: p => p.getByRole('heading', { name: 'Statistics', exact: true }),
+  },
+  // Dag — <h2 class="content-title">DAG</h2>
+  { name: 'dag', path: '/dag', heading: p => p.getByRole('heading', { name: 'DAG', exact: true }) },
+  // FeatureList — <Features title="Feature Activation" />
+  {
+    name: 'features',
+    path: '/features',
+    heading: p => p.getByText(/feature activation/i),
+  },
+  // PeerAdmin (network) — <h2 class="network-title">Network</h2>
+  {
+    name: 'network',
+    path: '/network',
+    heading: p => p.getByRole('heading', { name: 'Network', exact: true }),
+  },
+  // DecodeTx — <h2 class="title-page">Decode Transaction</h2>
+  {
+    name: 'decode-tx',
+    path: '/decode-tx',
+    heading: p => p.getByRole('heading', { name: /decode transaction/i }),
+  },
+  // PushTx — <h2 class="title-page">Push Transaction</h2>
+  {
+    name: 'push-tx',
+    path: '/push-tx',
+    heading: p => p.getByRole('heading', { name: /push transaction/i }),
+  },
+];
+```
+
+- [ ] **Step 4: Commit (user runs manually)**
+
+```bash
+git add tests/e2e/pages/ExplorerApp.ts tests/e2e/pages/NavigationBar.ts tests/e2e/pages/routes.ts
+git commit -m "feat(e2e): add ExplorerApp/NavigationBar page objects and smoke route registry"
+```
+
+---
+
+## Task 6: Fixture
+
+**Files:**
+- Create: `tests/e2e/fixtures/explorer-fixture.ts`
+
+- [ ] **Step 1: Create `tests/e2e/fixtures/explorer-fixture.ts`**
+
+```ts
+import { test as base } from '@playwright/test';
+import { ExplorerApp } from '../pages/ExplorerApp';
+import { NavigationBar } from '../pages/NavigationBar';
+
+type Fixtures = {
+  app: ExplorerApp;
+  nav: NavigationBar;
+};
+
+/**
+ * Page-scoped fixtures: a fresh page per test (the app is read-only, so tests are independent
+ * and parallel). Specs consume `{ app }` and/or `{ nav }`.
+ */
+export const test = base.extend<Fixtures>({
+  app: async ({ page }, use) => {
+    await use(new ExplorerApp(page));
+  },
+  nav: async ({ page }, use) => {
+    await use(new NavigationBar(page));
+  },
+});
+
+export const expect = test.expect;
+```
+
+- [ ] **Step 2: Commit (user runs manually)**
+
+```bash
+git add tests/e2e/fixtures/explorer-fixture.ts
+git commit -m "feat(e2e): add page-scoped explorer fixture (app + nav)"
+```
+
+---
+
+## Task 7: First smoke test — home route only (harness milestone)
+
+This is the milestone that proves the whole harness end to end: dev server boots with the
+mainnet env override, page objects resolve, and assertions run green against real backends.
+
+**Files:**
+- Create: `tests/e2e/navigation-smoke.spec.ts`
+
+- [ ] **Step 1: Write the failing test (home only)**
+
+Create `tests/e2e/navigation-smoke.spec.ts`:
+```ts
+import { test, expect } from './fixtures/explorer-fixture';
+import { SMOKE_ROUTES } from './pages/routes';
+
+test.describe('navigation smoke', () => {
+  test('home renders and the app is on mainnet', async ({ app, nav, page }) => {
+    const home = SMOKE_ROUTES.find(r => r.name === 'home')!;
+    await app.goto(home.path);
+
+    // Identifying element (waits past the version gate / initial Loading).
+    await expect(home.heading(page)).toBeVisible();
+
+    // Verifies the mainnet env override took effect (label rendered from REACT_APP_NETWORK).
+    await nav.expectVisible();
+    await nav.expectNetwork('mainnet');
+
+    await app.expectNoGlobalError();
+    await app.captureEvidence('home');
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect it to FAIL first for the right reason**
+
+Run (the webServer boots the dev server automatically; first boot is slow):
+```bash
+npm run e2e -- navigation-smoke.spec.ts 2>&1 | tail -40
+```
+Expected: with the harness fully wired this PASSES on first authoring (for an E2E harness the
+"red" state is the pre-Task-1 world where the command/config doesn't exist). If it FAILS,
+read the failure:
+- "Timed out waiting for ... live data" → the dev server didn't reach the home screen; check
+  the webServer booted on :3002 and the mainnet override resolved (inspect the `list`
+  reporter output / `playwright-report`).
+- `.nav-title` not "mainnet" → the env override did NOT win over `.env.local`; confirm
+  `webServer.env` is set and that no shell-exported REACT_APP_* contradicts it.
+
+- [ ] **Step 3: Make it pass**
+
+If Step 2 failed on the network label, the most likely cause is the env-precedence
+assumption. Debug by temporarily logging the resolved base URL: open the running app and
+check the Network tab targets `node.explorer.hathor.network` (not `localhost:8083`). If
+`.env.local` is winning, set the same vars via a `cross-env`-style inline prefix is NOT
+needed — instead ensure `webServer.env` is present (Playwright passes it as real process
+env, which CRA's dotenv will not override). Re-run:
+```bash
+npm run e2e -- navigation-smoke.spec.ts
+```
+Expected: `1 passed`. A `reports/screenshots/home.png` is produced.
+
+- [ ] **Step 4: Confirm the evidence screenshot exists**
+
+Run:
+```bash
+ls -la reports/screenshots/home.png
+```
+Expected: the file exists and is non-empty (the home page, styled — proves CSS compiled).
+
+- [ ] **Step 5: Commit (user runs manually)**
+
+```bash
+git add tests/e2e/navigation-smoke.spec.ts
+git commit -m "test(e2e): add navigation smoke for the home route (harness milestone)"
+```
+
+---
+
+## Task 8: Expand smoke to all routes (parameterized + per-route screenshots)
+
+**Files:**
+- Modify: `tests/e2e/navigation-smoke.spec.ts`
+
+- [ ] **Step 1: Replace the spec body with the parameterized route loop**
+
+Replace the entire contents of `tests/e2e/navigation-smoke.spec.ts` with:
+```ts
+import { test, expect } from './fixtures/explorer-fixture';
+import { SMOKE_ROUTES } from './pages/routes';
+
+test.describe('navigation smoke — every main route renders', () => {
+  for (const route of SMOKE_ROUTES) {
+    test(`${route.name} (${route.path}) renders with no global error`, async ({ app, page }) => {
+      await app.goto(route.path);
+
+      // Identifying element — waits past the version gate / initial Loading.
+      await expect(route.heading(page)).toBeVisible();
+
+      await app.expectNoGlobalError();
+      await app.captureEvidence(route.name);
+    });
+  }
+
+  test('app is on mainnet (env override took effect)', async ({ app, nav, page }) => {
+    await app.goto('/');
+    await expect(page.getByText(/^live data$/i)).toBeVisible();
+    await nav.expectVisible();
+    await nav.expectNetwork('mainnet');
+  });
+});
+```
+
+- [ ] **Step 2: Run the full route smoke**
+
+Run:
+```bash
+npm run e2e -- navigation-smoke.spec.ts 2>&1 | tail -50
+```
+Expected: all route tests pass (`12 passed` — 11 routes + the mainnet check). Any route that
+fails prints the exact missing locator; fix the locator in `pages/routes.ts` against the live
+DOM (open `npx playwright show-report` to inspect the failure screenshot).
+
+- [ ] **Step 3: Confirm one screenshot per route was captured**
+
+Run:
+```bash
+ls reports/screenshots/ | sort
+```
+Expected: `blocks.png decode-tx.png dag.png features.png home.png network.png push-tx.png
+statistics.png token-balances.png tokens.png transactions.png` (11 files).
+
+- [ ] **Step 4: Commit (user runs manually)**
+
+```bash
+git add tests/e2e/navigation-smoke.spec.ts
+git commit -m "test(e2e): cover all main routes in navigation smoke with per-route evidence"
+```
+
+---
+
+## Task 9: Nav-bar click navigation + footer
+
+**Files:**
+- Modify: `tests/e2e/navigation-smoke.spec.ts`
+
+- [ ] **Step 1: Append the nav-click + footer tests**
+
+Add these two tests inside the `test.describe(...)` block in
+`tests/e2e/navigation-smoke.spec.ts` (after the existing `mainnet` test):
+```ts
+  test('top-nav links navigate to their routes', async ({ app, nav, page }) => {
+    await app.goto('/');
+    await nav.expectVisible();
+
+    await nav.clickTopLink('Network');
+    await expect(page).toHaveURL(/\/network$/);
+    await expect(page.getByRole('heading', { name: 'Network', exact: true })).toBeVisible();
+
+    await nav.clickTopLink('Statistics');
+    await expect(page).toHaveURL(/\/statistics$/);
+    await expect(page.getByRole('heading', { name: 'Statistics', exact: true })).toBeVisible();
+
+    await nav.clickTopLink('Home');
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByText(/^live data$/i)).toBeVisible();
+  });
+
+  test('footer is present', async ({ app, page }) => {
+    await app.goto('/');
+    await expect(page.getByText(/^live data$/i)).toBeVisible();
+    await expect(
+      page.getByText(/hathor network ©\s*\d{4}\s*all rights reserved/i),
+    ).toBeVisible();
+  });
+```
+
+- [ ] **Step 2: Run the full suite**
+
+Run:
+```bash
+npm run e2e 2>&1 | tail -50
+```
+Expected: all tests pass (`14 passed` — 11 routes + mainnet + nav-click + footer). If the
+nav-click test fails because Network/Statistics links are hidden, the viewport may be too
+narrow — confirm `use.viewport` is `1366x900` in the config (Task 3).
+
+- [ ] **Step 3: Commit (user runs manually)**
+
+```bash
+git add tests/e2e/navigation-smoke.spec.ts
+git commit -m "test(e2e): add top-nav click navigation and footer presence checks"
+```
+
+---
+
+## Task 10: Final verification & docs touch-up
+
+**Files:**
+- Modify: `CLAUDE.md` (explorer) — document the e2e commands (optional but recommended)
+
+- [ ] **Step 1: Full clean run from scratch (no reused server)**
+
+Run (kills any dev server first so the webServer boots fresh, exercising the env override):
+```bash
+pkill -f "react-app-rewired" 2>/dev/null; npm run e2e 2>&1 | tail -30
+```
+Expected: `14 passed`. This is the authoritative green run.
+
+- [ ] **Step 2: Open the HTML report to eyeball the evidence**
+
+Run:
+```bash
+npx playwright show-report
+```
+Expected: the report opens; every test green; screenshots viewable. Close it when done
+(Ctrl-C).
+
+- [ ] **Step 3: Document the e2e commands in the explorer CLAUDE.md**
+
+In `/Users/rauloliveira/git/hathor/hathor-explorer/CLAUDE.md`, under the `### Testing`
+section (after the `npm test` line), add:
+```markdown
+
+#### E2E (Playwright)
+- `npm run e2e` - Run the E2E suite (boots the explorer against real mainnet backends)
+- `npm run e2e:headed` - Run with a visible browser
+- `npm run e2e:ui` - Open the Playwright UI runner
+- Conventions: see `tests/e2e/e2e.md` (read before writing any E2E test)
+```
+
+- [ ] **Step 4: Commit (user runs manually)**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(e2e): document Playwright e2e commands in explorer CLAUDE.md"
+```
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Selectors are grounded but live-verified.** Every identifier in `pages/routes.ts` and the
+  global-error texts were read from the real components, but the live mainnet DOM is the final
+  authority — if a heading assertion fails, inspect the failure screenshot in the HTML report
+  and adjust the locator, don't loosen the assertion blindly (rule #2 in `e2e.md`).
+- **Env precedence is the one real risk.** Task 7 Step 3 is the designated place to confirm
+  `webServer.env` wins over `.env.local`. If CRA's dotenv ever changes precedence, the
+  `nav.expectNetwork('mainnet')` assertion catches it immediately.
+- **Flag-gated routes** (`/tokens`, `/token_balances`) are asserted as present because the
+  mainnet flags are ON. If a flag is flipped off, the corresponding route test fails by design
+  (a real signal). Finer tolerance is intentionally deferred (see the design's Future
+  Iterations).
+- **Counts:** Task 8 expects 12 passed (11 routes + mainnet); Task 9 brings it to 14
+  (+nav-click +footer). Keep these in sync if routes are added/removed.
+```

--- a/docs/superpowers/specs/2026-06-16-explorer-e2e-navigation-smoke-design.md
+++ b/docs/superpowers/specs/2026-06-16-explorer-e2e-navigation-smoke-design.md
@@ -1,0 +1,264 @@
+# Explorer E2E — Infrastructure & Navigation Smoke Design
+
+**Date:** 2026-06-16
+**Status:** Approved (pending implementation plan)
+**Area:** `hathor-explorer` — new Playwright E2E suite driving the real explorer UI against
+real public backends.
+
+## Context
+
+The explorer has **no E2E tests** today (no Playwright, no `tests/e2e/`, only the unused CRA
+`react-app-rewired test` harness). We want to introduce an E2E suite modeled on the
+`hathor-rpc-lib-e2e` worktree's Playwright architecture — its layering, its
+conventions doc, its spec-driven discipline — adapted to the explorer.
+
+The crucial difference: the rpc-lib suite drives a **wallet** through the **real MetaMask
+Flask extension + the Hathor Snap**, which forces an entire `driver/` layer, a provisioning
+layer, seed config, a single-worker persistent context, and the "approve/reject the Snap in
+the spec" discipline. **The explorer has none of that.** It is a **read-only block explorer**:
+every screen just fetches from a fullnode API and the explorer-service backend and renders.
+There is no wallet, nothing to sign, no extension, no per-test state. That removes most of
+the rpc-lib machinery and lets the explorer suite be simpler and fully parallel.
+
+## Goals
+
+- Stand up the full E2E **infrastructure** (Playwright config, fixture, page-object layer,
+  conventions doc, immutable test anchors, npm scripts) so adding future journeys is cheap.
+- Ship one **navigation smoke** journey that proves the harness end to end: every main route
+  renders its identifying content with no global error state.
+- Drive the **real** explorer against **real public mainnet backends** with **real Unleash**
+  feature flags (never `SKIP_FEATURE_TOGGLE`).
+- Keep the suite isolated from the app build (`src/` stays JS/airbnb; tests are TypeScript
+  under their own tsconfig).
+
+## Non-Goals (deferred to later iterations)
+
+- Genesis detail pages (deterministic tx/block detail via immutable anchors).
+- List pages + pagination + click-through (TransactionList, BlockList).
+- Search, Token (list/detail/balances), and Address detail journeys.
+- Tools (decode-tx, push-tx) functional flows, nano contracts / blueprints.
+- A CI workflow (GitHub Actions). Intentionally out of v1; planned as a later iteration.
+- Visual/screenshot regression (`toHaveScreenshot`). Intentionally out of v1; planned as a
+  later iteration. It is **not** a fit for this smoke suite ("renders without error"), and it
+  fights the live-mainnet data source: real pages have non-deterministic content (live
+  metrics, latest tx/block lists, rising block height), so a future visual-regression
+  iteration must target deterministic surfaces only — immutable anchors (genesis tx/block
+  detail) and/or the static chrome (nav, footer, layout) with dynamic regions masked
+  (`mask: [...]`). It also needs platform-stable baselines (goldens generated in the official
+  Playwright Docker image, since rendering differs per OS). See "Future iterations" below.
+
+## Key decisions (confirmed)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Data source | **Real public backends** (app under test runs locally) | Most faithful translation of rpc-lib (local app + real network + real Unleash). Zero blockchain infra. |
+| Network | **Mainnet** | Production deployment: most stable, most data, genesis well-known, feature flags ON → fullest route coverage. |
+| Test language | **TypeScript** | Typed page objects, matches rpc-lib; Playwright runs TS natively; scoped tsconfig keeps it off the app build. |
+| Parallelism | **`fullyParallel: true`** | No extension → no persistent context → read-only, stateless app → every test independent. (rpc-lib's `workers: 1` constraint does not apply.) |
+| CI | **Deferred** | v1 ships local infra + spec only. |
+| First journey | **Navigation smoke only** | Validates the whole harness at lowest cost. |
+
+## How the explorer gets its data (verified in source)
+
+- `BASE_URL` (`src/constants.js`) — fullnode API, default
+  `https://node.explorer.hathor.network/v1a/`. Used for version, tx/block detail, DAG.
+- `EXPLORER_SERVICE_BASE_URL` — explorer-service backend, default
+  `https://explorer-service.hathor.network/`. Backs token list, address detail, token
+  balances (Elasticsearch-fed).
+- `WS_URL` — websocket for the home dashboard's live metrics.
+- `UNLEASH_CONFIG` — real Unleash proxy; flags are **per-network**
+  (`explorer-tokens-${network}`, `explorer-new-ui-enabled-${network}`, ...).
+- `App.js` runs a **version gate** on mount: it calls `versionApi.getVersion()`, and until it
+  resolves the app renders only `<Loading/>` (or `<ErrorMessage/>` on failure). If the node
+  version is below `MIN_API_VERSION` it renders `<VersionError/>` instead of the app. Every
+  smoke assertion must wait past this gate.
+- `EXPLORER_MODE` (`full` by default) gates a set of routes (`/tokens`, `/token_balances`,
+  `/dag`, `/features`, `/network`, `/statistics`, `/address/:address`, `/push-tx`,
+  `/decode-tx`) behind `helpers.isExplorerModeFull()`. v1 runs in full mode.
+
+## Architecture
+
+Three roles. Each has one job. (Compare rpc-lib's four roles — the explorer drops the
+MetaMask **driver** and the **provisioning** layers entirely.)
+
+| Layer | File(s) | Job | Called by |
+|---|---|---|---|
+| **Page object** | `tests/e2e/pages/*.ts` | Granular UI steps for one screen/region: navigate to a route, read a heading, click a nav link, assert the screen's identifying element, assert no error state. | Specs (and the fixture) |
+| **Fixture** | `tests/e2e/fixtures/explorer-fixture.ts` | Hands the spec an app that has **passed the version gate** (app shell rendered, not `Loading`/`VersionError`) plus instantiated page objects. Page-scoped (fresh page per test). | Playwright runner |
+| **Spec** | `tests/e2e/*.spec.ts` | The scenario: navigate + assert. v1 = `navigation-smoke.spec.ts`. | Playwright runner |
+| **Anchors** | `tests/e2e/support/anchors.ts` | Immutable test data mirroring `src/constants.js` (genesis tx/block ids per network, known token UIDs) so specs never hardcode chain data. Unused by the smoke spec but established now for the next iterations. | Specs |
+| **Conventions** | `tests/e2e/e2e.md` | The rules. Read before reading/writing any test. | Humans |
+| **Config** | `playwright.e2e.config.ts` (repo root) | `webServer` boots the local explorer; `baseURL`, reporters, timeouts. | Playwright runner |
+
+### Page object boundaries
+
+Mirror rpc-lib's "page object is decoupled, asserts only verified UI" rule:
+
+- A page object knows **one screen** (or one shared region like the nav bar). It exposes
+  intent-level verbs (`goto()`, `expectLoaded()`, `clickNavLink(name)`), never raw selectors
+  to the spec.
+- It asserts **only what the real component renders** — verified by reading the component
+  and/or inspecting the live DOM during implementation, never assumed.
+- Initial set for v1:
+  - `ExplorerApp.ts` — app shell: wait past the version gate; assert no global error
+    (`ErrorMessage`, `VersionError`, ChunkErrorBoundary fallback).
+  - `NavigationBar.ts` — the top nav: click a named link, assert the active route.
+  - `HomePage.ts` — the `/` dashboard (DashboardTx): its identifying element.
+  - One thin `RouteScreen` helper (or per-route assertions) covering the remaining smoke
+    routes by their identifying heading/region. (Whether these become individual page-object
+    classes or one parameterized helper is an implementation detail; the smoke spec only needs
+    "this route rendered its content, no error".)
+
+## Environment wiring (the one integration subtlety)
+
+The local dev server must point at **public mainnet backends**, overriding the committed
+`.env.local` (which points at the localnet docker, `localhost:8083`). Playwright's
+`webServer.env` sets OS-level env for the spawned process; CRA's dotenv loader **does not
+override variables already present in `process.env`**, so OS env wins over `.env.local`.
+That is the mechanism we rely on.
+
+```
+// playwright.e2e.config.ts (sketch)
+webServer: {
+  // `npm start` (not `start-js`) so the SCSS is compiled+watched alongside the dev server —
+  // `start-js` alone skips CSS, which can make styled elements read as hidden in Playwright.
+  command: 'npm start',
+  url: 'http://localhost:3002',
+  reuseExistingServer: !process.env.CI,
+  timeout: 180_000,
+  env: {
+    BROWSER: 'none',                 // don't auto-open a browser tab
+    PORT: '3002',
+    REACT_APP_BASE_URL: 'https://node.explorer.hathor.network/v1a/',
+    REACT_APP_EXPLORER_SERVICE_BASE_URL: 'https://explorer-service.hathor.network/',
+    REACT_APP_WS_URL: 'wss://node.explorer.hathor.network/v1a/ws/',
+    REACT_APP_NETWORK: 'mainnet',
+    REACT_APP_EXPLORER_MODE: 'full',
+    // no SKIP_FEATURE_TOGGLE -> real Unleash
+  },
+},
+use: {
+  baseURL: 'http://localhost:3002',
+  trace: 'on-first-retry',
+  video: 'retain-on-failure',
+  screenshot: 'only-on-failure',   // failure evidence, embedded in the HTML report
+},
+fullyParallel: true,
+timeout: 60_000,
+expect: { timeout: 20_000 },
+reporter: [['html', { open: 'never' }], ['list']],
+```
+
+**Implementation must verify** the env override actually takes effect (e.g. assert the app
+loaded mainnet data, or log the resolved `BASE_URL`) before trusting the suite — this is the
+one place the CRA/dotenv precedence assumption could bite.
+
+## Navigation smoke spec (v1 content)
+
+`navigation-smoke.spec.ts`, fully parallel. For each route below: navigate, wait past the
+version gate, assert the screen's identifying element is visible, and assert **no** global
+error state. Plus nav-bar navigation and footer presence.
+
+Routes (full mode, mainnet): `/` (home dashboard), `/transactions`, `/blocks`, `/tokens`,
+`/token_balances`, `/statistics`, `/dag`, `/features`, `/network`, `/decode-tx`, `/push-tx`.
+
+- Unleash-gated screens (`/tokens`, `/token_balances`, ...) follow the rpc-lib rule: **wait
+  for the flag-gated UI** (toggles re-fetch async). On mainnet these flags are ON; if a flag
+  is unexpectedly off, the assertion is written to tolerate absence rather than hang.
+- Identifying elements are taken from the **real components** (verified during
+  implementation). Prefer role/heading/text selectors over structural ones, matching the
+  rpc-lib selector discipline.
+- "No global error" = none of `ErrorMessage`, `VersionError`, the ChunkErrorBoundary
+  fallback ("Failed to load this page"), and the page is not stuck on `Loading`.
+
+### Screenshot evidence (v1)
+
+Two layers, no visual comparison (regression is a future iteration):
+
+- **On failure** — `screenshot: 'only-on-failure'` in the config `use` (above), so a failing
+  route attaches a PNG to the HTML report automatically.
+- **Per route, always** — after asserting a route rendered, the spec captures an intentional
+  artifact: `await page.screenshot({ path: 'reports/screenshots/<route>.png', fullPage: true })`.
+  These are evidence/inspection artifacts only — never diffed against a baseline. Output dir
+  (`reports/screenshots/`) is gitignored.
+
+## New UI vs old UI
+
+`explorer-new-ui-enabled-mainnet` (real Unleash) decides which UI renders. The suite asserts
+against **whatever the real flag resolves to** — consistent with "use real Unleash, never
+skip it." Implementation inspects the live DOM (Playwright snapshot) to write selectors
+against the UI that actually renders; if both UIs must be supported later, selectors will be
+chosen to match either, but v1 targets the real rendered UI only.
+
+## Conventions doc (`tests/e2e/e2e.md`)
+
+A trimmed analog of rpc-lib's `e2e.md`, encoding the explorer's rules:
+
+1. Drive the real explorer against real public backends; use real Unleash, never skip it.
+2. Assert only what the UI renders — verify against the real component first.
+3. Always wait past the version gate before asserting any screen content.
+4. Page objects are decoupled and screen-scoped; specs compose them.
+5. Tests are independent and parallel (read-only app, no shared state) — never rely on
+   ordering or on another test's effect.
+6. Immutable chain data lives in `support/anchors.ts`, mirroring `src/constants.js`.
+
+## Deliverables (v1)
+
+- `playwright.e2e.config.ts` (repo root) — webServer + baseURL + reporters + `fullyParallel`.
+- `tests/e2e/e2e.md` — conventions.
+- `tests/e2e/fixtures/explorer-fixture.ts` — version-gate-aware fixture + page objects.
+- `tests/e2e/pages/ExplorerApp.ts`, `NavigationBar.ts`, `HomePage.ts` (+ route assertions).
+- `tests/e2e/support/anchors.ts` — immutable anchors (mirrors `src/constants.js`).
+- `tests/e2e/navigation-smoke.spec.ts` — the v1 journey.
+- `tests/e2e/tsconfig.json` — scoped TS config for the suite.
+- `package.json` — devDeps (`@playwright/test`, `typescript`, `@types/node`) + scripts
+  (`e2e`, `e2e:headed`, `e2e:ui`).
+- `.gitignore` — `playwright-report/`, `test-results/`, `reports/screenshots/`.
+
+## Growth model
+
+- **New journey** = +1 spec + the page object(s) it needs. No new infra.
+- **New screen** = +1 page object reused across specs.
+- Deterministic detail-page journeys consume `support/anchors.ts`; list journeys assert
+  structurally; both reuse the same fixture and config.
+
+## Future iterations (explicit to-go list)
+
+Deferred from v1 on purpose; each reuses the v1 infrastructure (config, fixture, page
+objects, anchors) with no new harness work:
+
+1. **Genesis detail pages** — deterministic tx/block detail via the immutable anchors.
+2. **List pages + pagination** — TransactionList, BlockList: rows render, prev/next paging,
+   click-through to a detail page.
+3. **Search + Token/Address** — search by id/address; TokenList, TokenDetail, TokenBalances,
+   AddressDetail (Unleash-gated screens).
+4. **CI workflow (GitHub Actions)** — run the suite on PRs (`npm ci` → `npx playwright install
+   --with-deps chromium` → `npm run e2e`), uploading the HTML report / traces as artifacts.
+5. **Visual regression (`toHaveScreenshot`)** — its **own** iteration, not bolted onto smoke.
+   Targets deterministic surfaces only (genesis detail, or static chrome with dynamic regions
+   masked), with platform-stable baselines generated in the official Playwright Docker image.
+   See the Non-Goals note for why it is unfit for the live-data smoke suite.
+
+## Risks / open details
+
+- **CRA/dotenv precedence**: the env override via `webServer.env` is standard dotenv
+  behavior but must be verified in implementation (see Environment wiring). **Verified during
+  implementation** — the `mainnet` nav label confirms the override wins over `.env.local`.
+- **Cross-origin backends / CORS** (discovered during implementation): the real backends only
+  allow `Access-Control-Allow-Origin: https://explorer.hathor.network`, so API calls from
+  `http://localhost:3002` are blocked and the app falls into the `ErrorMessage` gate. **v1
+  decision (user-approved):** launch Chromium with `--disable-web-security` (scoped to the
+  test browser, `use.launchOptions` — touches nothing in the app). Tradeoff: disables the
+  same-origin policy wholesale (a known E2E smell). **Cleaner alternatives, deferred:**
+  (1) origin remap à la hathor-rpc-lib — `baseURL = https://explorer.hathor.network` + HTTPS
+  dev server + `--host-resolver-rules=MAP explorer.hathor.network:443 127.0.0.1:3002`, so the
+  browser legitimately sits on the allowed origin with no security disabled; (2) a CRA dev
+  proxy (`setupProxy.js`) making API calls same-origin. Revisit if v1's flag becomes a problem
+  (e.g. when wiring CI).
+- **Public backend availability/latency**: real mainnet backends can be slow or briefly
+  unavailable; timeouts are generous and `trace`/`video` capture failures. Flakiness from
+  the live network is an accepted tradeoff of the "real backends" decision.
+- **Unleash flag drift**: a flag flipping off on mainnet could change which routes render;
+  smoke assertions for gated routes tolerate absence to avoid false failures.
+- **Spec doc commit**: per the user's git policy, this document is written but **not
+  committed** by the assistant; the user commits manually.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,8 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "7.26.8",
+        "@playwright/test": "^1.50.1",
+        "@types/node": "^22.13.1",
         "eslint-config-airbnb-base": "14.2.1",
         "eslint-config-prettier": "6.15.0",
         "eslint-plugin-prettier": "3.1.4",
@@ -50,7 +52,8 @@
         "react-app-rewired": "2.2.1",
         "stylelint": "16.12.0",
         "stylelint-config-standard-scss": "14.0.0",
-        "stylelint-scss": "6.10.0"
+        "stylelint-scss": "6.10.0",
+        "typescript": "^5.7.3"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -3615,6 +3618,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.15.tgz",
@@ -4545,9 +4564,10 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -14978,6 +14998,53 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/popper.js": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
@@ -20346,17 +20413,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "lint:scss:fix": "stylelint '**/*.scss' --fix",
     "format": "prettier --write 'src/**/*.js'",
     "format:check": "prettier --check 'src/**/*.js'",
+    "e2e": "playwright test --config playwright.e2e.config.ts",
+    "e2e:headed": "playwright test --config playwright.e2e.config.ts --headed",
+    "e2e:ui": "playwright test --config playwright.e2e.config.ts --ui",
     "eject": "react-scripts eject",
     "postinstall": "patch-package"
   },
@@ -63,6 +66,8 @@
   ],
   "devDependencies": {
     "@babel/eslint-parser": "7.26.8",
+    "@playwright/test": "^1.50.1",
+    "@types/node": "^22.13.1",
     "eslint-config-airbnb-base": "14.2.1",
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-prettier": "3.1.4",
@@ -71,7 +76,8 @@
     "react-app-rewired": "2.2.1",
     "stylelint": "16.12.0",
     "stylelint-config-standard-scss": "14.0.0",
-    "stylelint-scss": "6.10.0"
+    "stylelint-scss": "6.10.0",
+    "typescript": "^5.7.3"
   },
   "overrides": {
     "react-refresh": "0.14.0"

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * E2E suite for hathor-explorer. Playwright boots the app's own CRA dev server locally and
+ * points it at the REAL public mainnet backends. The explorer is read-only and stateless, so
+ * tests run fully parallel.
+ *
+ * Env override: `webServer.env` sets OS-level env for the spawned dev server. CRA's dotenv
+ * loader does NOT override variables already present in process.env, so these win over the
+ * committed `.env.local` (which targets the localnet docker).
+ */
+const PORT = 3002;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  tsconfig: './tests/e2e/tsconfig.json',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  // Real public backends can be slow; be generous.
+  timeout: 60_000,
+  expect: { timeout: 20_000 },
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: BASE_URL,
+    viewport: { width: 1366, height: 900 }, // desktop: top-nav links are visible (not mobile burger)
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    // The explorer-service API Gateway only allows CORS from https://explorer.hathor.network.
+    // When running locally against localhost:3002 we must bypass CORS enforcement so the
+    // versionApi.getVersion() and other explorer-service calls succeed in the browser.
+    launchOptions: {
+      args: ['--disable-web-security', '--disable-features=IsolateOrigins,site-per-process'],
+    },
+  },
+  webServer: {
+    // `npm start` (not `start-js`) so the SCSS is compiled+watched alongside the dev server —
+    // `start-js` alone skips CSS, which can make styled elements read as hidden in Playwright.
+    command: 'npm start',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      BROWSER: 'none', // don't auto-open a browser tab
+      PORT: String(PORT),
+      REACT_APP_BASE_URL: 'https://node.explorer.hathor.network/v1a/',
+      REACT_APP_EXPLORER_SERVICE_BASE_URL: 'https://explorer-service.hathor.network/',
+      REACT_APP_WS_URL: 'wss://node.explorer.hathor.network/v1a/ws/',
+      REACT_APP_NETWORK: 'mainnet',
+      REACT_APP_EXPLORER_MODE: 'full',
+      // no SKIP_FEATURE_TOGGLE -> real Unleash
+    },
+  },
+});

--- a/tests/e2e/e2e.md
+++ b/tests/e2e/e2e.md
@@ -1,0 +1,71 @@
+# Explorer E2E — Architecture & Conventions
+
+**Read this before reading or writing any test in `tests/e2e/`.**
+
+These tests drive the **real explorer UI** against **real public mainnet backends**
+(`node.explorer.hathor.network` + `explorer-service.hathor.network`) with **real Unleash**
+feature flags. Unlike the wallet, the explorer is **read-only**: no wallet, nothing to sign,
+no extension, no per-test state. The suite is therefore simpler than the wallet's and runs
+fully parallel.
+
+## The rules that matter most
+
+1. **Drive the real explorer against real public backends. Use real Unleash — never skip it.**
+   The dev server runs WITHOUT `SKIP_FEATURE_TOGGLE`; flag-gated UI must resolve from the real
+   proxy. Flags are per-network (`explorer-tokens-mainnet`, ...).
+2. **Assert only what the UI actually renders — verify against the real component first.**
+   Never assume a heading/value is present; read the screen's component (e.g. `src/screens/*`)
+   or inspect the live DOM, then assert.
+3. **Always wait past the version gate.** `App.js` shows `<Loading/>` until
+   `versionApi.getVersion()` resolves, and `<VersionError/>` if the node version is too old.
+   A per-route heading assertion (with a generous timeout) inherently waits past this.
+4. **Page objects are decoupled and screen-scoped.** They expose intent-level verbs
+   (`goto`, `expectLoaded`, `clickTopLink`), never raw selectors to the spec.
+5. **Tests are independent and parallel** (read-only app, no shared state). Never rely on
+   ordering or on another test's effect.
+6. **Immutable chain data lives in `support/anchors.ts`**, mirroring `src/constants.js`.
+
+## Layering
+
+| Layer | File | Job |
+|-------|------|-----|
+| Page object | `pages/*.ts` | Granular UI steps for one screen/region. |
+| Fixture | `fixtures/explorer-fixture.ts` | Exposes `app` (ExplorerApp) + `nav` (NavigationBar) on a fresh page. |
+| Spec | `*.spec.ts` | The scenario: navigate + assert. |
+
+## Global error / blocked states (what "no error" means)
+
+- `VersionError`  → text "Please update you API version and try again"
+- `ErrorMessage`  → text "Error loading."
+- ChunkErrorBoundary → text "Failed to load this page"
+
+## Backends & CORS (why the browser launches with `--disable-web-security`)
+
+The real backends (`node.explorer.hathor.network`, `explorer-service.hathor.network`) only
+send `Access-Control-Allow-Origin: https://explorer.hathor.network`. Running the app from
+`http://localhost:3002`, the browser blocks every API call, so `versionApi.getVersion()` fails
+and the app renders the `ErrorMessage` ("Error loading.") gate instead of any screen.
+
+To make the real-backend smoke work from localhost, the Playwright config launches Chromium
+with `--disable-web-security` (in `playwright.e2e.config.ts` → `use.launchOptions`). This is
+scoped to the test browser only — it touches nothing in the app. It is a deliberate, known
+E2E tradeoff (it disables the same-origin policy wholesale). Cleaner alternatives exist and
+are recorded in the design doc's risks section (origin remap à la hathor-rpc-lib, or a dev
+proxy); they were deferred for v1.
+
+## File map
+
+```
+tests/e2e/
+  e2e.md                       # this file
+  tsconfig.json                # scoped TS config (NOT at repo root)
+  support/anchors.ts           # immutable on-chain anchors
+  pages/
+    ExplorerApp.ts             # app shell: goto, no-global-error, evidence screenshot
+    NavigationBar.ts           # top nav: brand/links, network label, click link
+    routes.ts                  # SMOKE_ROUTES registry (route -> identifying locator)
+  fixtures/explorer-fixture.ts # app + nav fixtures
+  navigation-smoke.spec.ts     # the v1 journey
+```
+
+> Config (`playwright.e2e.config.ts`) lives at the repo root.

--- a/tests/e2e/fixtures/explorer-fixture.ts
+++ b/tests/e2e/fixtures/explorer-fixture.ts
@@ -1,0 +1,23 @@
+import { test as base } from '@playwright/test';
+import { ExplorerApp } from '../pages/ExplorerApp';
+import { NavigationBar } from '../pages/NavigationBar';
+
+type Fixtures = {
+  app: ExplorerApp;
+  nav: NavigationBar;
+};
+
+/**
+ * Page-scoped fixtures: a fresh page per test (the app is read-only, so tests are independent
+ * and parallel). Specs consume `{ app }` and/or `{ nav }`.
+ */
+export const test = base.extend<Fixtures>({
+  app: async ({ page }, use) => {
+    await use(new ExplorerApp(page));
+  },
+  nav: async ({ page }, use) => {
+    await use(new NavigationBar(page));
+  },
+});
+
+export const expect = test.expect;

--- a/tests/e2e/navigation-smoke.spec.ts
+++ b/tests/e2e/navigation-smoke.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from './fixtures/explorer-fixture';
+import { SMOKE_ROUTES } from './pages/routes';
+
+test.describe('navigation smoke — every main route renders', () => {
+  for (const route of SMOKE_ROUTES) {
+    test(`${route.name} (${route.path}) renders with no global error`, async ({ app, page }) => {
+      await app.goto(route.path);
+
+      // Identifying element — waits past the version gate / initial Loading.
+      await expect(route.heading(page)).toBeVisible();
+
+      await app.expectNoGlobalError();
+      await app.captureEvidence(route.name);
+    });
+  }
+
+  test('app is on mainnet (env override took effect)', async ({ app, nav, page }) => {
+    await app.goto('/');
+    await expect(page.getByText(/^live data$/i)).toBeVisible();
+    await nav.expectVisible();
+    await nav.expectNetwork('mainnet');
+  });
+
+  test('top-nav links navigate to their routes', async ({ app, nav, page }) => {
+    await app.goto('/');
+    await nav.expectVisible();
+
+    await nav.clickTopLink('Network');
+    await expect(page).toHaveURL(/\/network$/);
+    await expect(page.getByRole('heading', { name: 'Network', exact: true })).toBeVisible();
+
+    await nav.clickTopLink('Statistics');
+    await expect(page).toHaveURL(/\/statistics$/);
+    await expect(page.getByRole('heading', { name: 'Statistics', exact: true })).toBeVisible();
+
+    await nav.clickTopLink('Home');
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByText(/^live data$/i)).toBeVisible();
+  });
+
+  test('footer is present', async ({ app, page }) => {
+    await app.goto('/');
+    await expect(page.getByText(/^live data$/i)).toBeVisible();
+    await expect(
+      page.getByText(/hathor network ©\s*\d{4}\s*all rights reserved/i),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/pages/ExplorerApp.ts
+++ b/tests/e2e/pages/ExplorerApp.ts
@@ -1,0 +1,37 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * App-shell page object. Decoupled from any single screen: it navigates, asserts the absence
+ * of the global error/blocked states, and captures evidence screenshots.
+ */
+export class ExplorerApp {
+  constructor(private readonly page: Page) {}
+
+  /** Navigate to a route (relative to baseURL). */
+  async goto(path: string): Promise<void> {
+    await this.page.goto(path);
+  }
+
+  /**
+   * Assert none of the global blocked states are rendered:
+   *  - VersionError (node version too old)
+   *  - ErrorMessage (initial API load failed)
+   *  - ChunkErrorBoundary fallback (lazy chunk failed to load)
+   * Call this AFTER asserting a screen's identifying element, so the app has settled.
+   */
+  async expectNoGlobalError(): Promise<void> {
+    await expect(
+      this.page.getByText(/please update you api version and try again/i),
+    ).toHaveCount(0);
+    await expect(this.page.getByText(/^error loading\.$/i)).toHaveCount(0);
+    await expect(this.page.getByText(/failed to load this page/i)).toHaveCount(0);
+  }
+
+  /**
+   * Capture a full-page evidence screenshot (no baseline comparison — visual regression is a
+   * future iteration). Playwright creates the parent dirs automatically.
+   */
+  async captureEvidence(name: string): Promise<void> {
+    await this.page.screenshot({ path: `reports/screenshots/${name}.png`, fullPage: true });
+  }
+}

--- a/tests/e2e/pages/NavigationBar.ts
+++ b/tests/e2e/pages/NavigationBar.ts
@@ -1,0 +1,32 @@
+import { expect, type Page } from '@playwright/test';
+
+type TopLink = 'Home' | 'Network' | 'Statistics';
+
+/**
+ * Top navigation bar page object. The explorer always renders the "new UI" nav
+ * (`Navigation.renderNewUi`). Home/Network/Statistics are direct NavLinks; Tokens/Tools/Nano
+ * are Bootstrap dropdowns (not exercised by the smoke nav-click check).
+ */
+export class NavigationBar {
+  constructor(private readonly page: Page) {}
+
+  /** The nav is present once the brand logo link is visible. */
+  async expectVisible(): Promise<void> {
+    await expect(this.page.locator('nav a.navbar-brand')).toBeVisible();
+  }
+
+  /**
+   * Assert the network label under the logo. Doubles as verification that the mainnet env
+   * override took effect: the label is rendered straight from REACT_APP_NETWORK.
+   */
+  async expectNetwork(name: string): Promise<void> {
+    await expect(this.page.locator('nav .nav-title')).toHaveText(name);
+  }
+
+  /** Click a top-level (non-dropdown) nav link by its visible text.
+   *  Scoped to the .nav-tabs-container to avoid matching the <Sidebar> (an <aside> nested
+   *  inside <nav>) which also has the same links but is hidden on desktop viewports. */
+  async clickTopLink(name: TopLink): Promise<void> {
+    await this.page.locator('.nav-tabs-container').getByRole('link', { name, exact: true }).click();
+  }
+}

--- a/tests/e2e/pages/routes.ts
+++ b/tests/e2e/pages/routes.ts
@@ -1,0 +1,73 @@
+import { type Locator, type Page } from '@playwright/test';
+
+/**
+ * A smoke route: its URL, a stable name (test title + screenshot filename), and the locator
+ * for the element that uniquely identifies "this screen rendered". Identifiers are taken from
+ * the real components in `src/screens/*` (verified) — prefer role/heading/text over structure.
+ */
+export interface RouteSpec {
+  name: string;
+  path: string;
+  heading: (page: Page) => Locator;
+}
+
+export const SMOKE_ROUTES: RouteSpec[] = [
+  // DashboardTx — src/screens/DashboardTx.js: <p class="title-page data-title">Live Data</p>
+  { name: 'home', path: '/', heading: p => p.getByText(/^live data$/i) },
+  // TransactionList — <h1 class="title-tx-page">Transactions</h1>
+  {
+    name: 'transactions',
+    path: '/transactions',
+    heading: p => p.getByRole('heading', { name: 'Transactions', exact: true }),
+  },
+  // BlockList — <h1 class="title-tx-page">Blocks</h1>
+  {
+    name: 'blocks',
+    path: '/blocks',
+    heading: p => p.getByRole('heading', { name: 'Blocks', exact: true }),
+  },
+  // TokenList — <p class="title-page">Tokens</p> (Unleash explorer-tokens-mainnet; ON in prod)
+  {
+    name: 'tokens',
+    path: '/tokens',
+    heading: p => p.locator('p.title-page', { hasText: /^Tokens$/ }),
+  },
+  // TokenBalances — <p class="title-page">Token Balance</p> (Unleash explorer-address-list-mainnet)
+  {
+    name: 'token-balances',
+    path: '/token_balances',
+    heading: p => p.locator('p.title-page', { hasText: /token balance/i }),
+  },
+  // Dashboard (statistics) — <h2 class="statistics-title">Statistics</h2>
+  {
+    name: 'statistics',
+    path: '/statistics',
+    heading: p => p.getByRole('heading', { name: 'Statistics', exact: true }),
+  },
+  // Dag — <h2 class="content-title">DAG</h2>
+  { name: 'dag', path: '/dag', heading: p => p.getByRole('heading', { name: 'DAG', exact: true }) },
+  // FeatureList — <Features title="Feature Activation" />
+  {
+    name: 'features',
+    path: '/features',
+    heading: p => p.getByText(/feature activation/i),
+  },
+  // PeerAdmin (network) — <h2 class="network-title">Network</h2>
+  {
+    name: 'network',
+    path: '/network',
+    heading: p => p.getByRole('heading', { name: 'Network', exact: true }),
+  },
+  // DecodeTx — <h2 class="title-page">Decode Transaction</h2>
+  {
+    name: 'decode-tx',
+    path: '/decode-tx',
+    heading: p => p.getByRole('heading', { name: /decode transaction/i }),
+  },
+  // PushTx — <h2 class="title-page">Push Transaction</h2>
+  {
+    name: 'push-tx',
+    path: '/push-tx',
+    heading: p => p.getByRole('heading', { name: /push transaction/i }),
+  },
+];

--- a/tests/e2e/support/anchors.ts
+++ b/tests/e2e/support/anchors.ts
@@ -1,0 +1,25 @@
+/**
+ * Immutable on-chain anchors, mirrored from `src/constants.js`. Deterministic detail-page
+ * journeys (future iterations) reference these so specs never hardcode chain data. The
+ * navigation-smoke journey does not use them yet — they are established here for reuse.
+ */
+export const MAINNET_GENESIS_BLOCK = [
+  '000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc',
+] as const;
+
+export const MAINNET_GENESIS_TX = [
+  '0002d4d2a15def7604688e1878ab681142a7b155cbe52a6b4e031250ae96db0a',
+  '0002ad8d1519daaddc8e1a37b14aac0b045129c01832281fb1c02d873c7abbf9',
+] as const;
+
+export const TESTNET_GENESIS_BLOCK = [
+  '0000033139d08176d1051fb3a272c3610457f0c7f686afbe0afe3d37f966db85',
+] as const;
+
+export const TESTNET_GENESIS_TX = [
+  '00e161a6b0bee1781ea9300680913fb76fd0fac4acab527cd9626cc1514abdc9',
+  '00975897028ceb037307327c953f5e7ad4d3f42402d71bd3d11ecb63ac39f01a',
+] as const;
+
+/** Native token (HTR) uid used across the explorer. */
+export const HTR_UID = '00';

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2021", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../../playwright.e2e.config.ts"]
+}


### PR DESCRIPTION
### Description

Adds a Playwright E2E suite for the explorer (there were none) plus a first navigation-smoke journey. Modeled on the `hathor-rpc-lib-e2e` architecture, minus the wallet/MetaMask/Snap layers (the explorer is read-only). Playwright boots the explorer's own CRA dev server locally and runs it against the real public **mainnet** backends with real Unleash; the read-only, stateless app runs fully parallel.

### Acceptance Criteria

- E2E harness in place: Playwright config (mainnet env override), scoped `tests/e2e/tsconfig.json`, conventions doc (`tests/e2e/e2e.md`), immutable anchors, page objects and a page-scoped fixture.
- `e2e` / `e2e:headed` / `e2e:ui` npm scripts added; `playwright-report/`, `test-results/`, `reports/screenshots/` gitignored.
- Navigation smoke covers all 11 main routes (`/`, `/transactions`, `/blocks`, `/tokens`, `/token_balances`, `/statistics`, `/dag`, `/features`, `/network`, `/decode-tx`, `/push-tx`): each renders its identifying element with no global error state, capturing a per-route evidence screenshot.
- Asserts the mainnet env override took effect, top-nav click navigation and footer presence.
- Suite is green: 14/14 passing against real mainnet.
- The test browser launches with `--disable-web-security` (the real backends only allow the production origin); scoped to the test browser, nothing in the app changes. Cleaner alternatives are recorded in the design doc.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. The only new dependencies are test-only devDependencies (`@playwright/test`, `typescript`, `@types/node`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
