### PR TITLE
feat(decimal): display full 8-decimal amounts with BigInt precision

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,4 +79,12 @@ module.exports = {
       version: 'detect',
     },
   },
+  overrides: [
+    {
+      files: ['**/*.test.js', '**/*.test.jsx'],
+      env: {
+        jest: true,
+      },
+    },
+  ],
 };

--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -7,6 +7,7 @@
 
 import axios from 'axios';
 import { EXPLORER_SERVICE_BASE_URL } from '../constants';
+import { parseJsonBigInt } from './jsonBigIntResponse';
 
 const errorHandler = error => {
   console.log('ERROR RESPONSE', error);
@@ -18,6 +19,10 @@ const requestExplorerServiceV1 = () => {
     headers: {
       'Content-Type': 'application/json',
     },
+    // Preserve full integer precision: at 18 decimals, base-unit amounts exceed
+    // Number.MAX_SAFE_INTEGER, which the default JSON parsing rounds silently.
+    // Overriding transformResponse replaces axios' default JSON.parse.
+    transformResponse: [parseJsonBigInt],
   };
 
   const instance = axios.create(defaultOptions);

--- a/src/api/jsonBigIntResponse.js
+++ b/src/api/jsonBigIntResponse.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import hathorLib from '@hathor/wallet-lib';
+
+/**
+ * Parse an Explorer Service HTTP response body preserving full integer precision.
+ *
+ * At 18 decimal places, base-unit amounts routinely exceed Number.MAX_SAFE_INTEGER
+ * (~2^53), which the default JSON.parse silently rounds. This uses wallet-lib's
+ * JSONBigInt, which upgrades only out-of-safe-range integers to BigInt and leaves
+ * everything else (timestamps, heights, counts, floats) as Number.
+ *
+ * It is defensive so it can be used as an Axios `transformResponse`: non-string or
+ * empty bodies are returned as-is, and non-JSON bodies (e.g. graphviz output) fall
+ * back to the raw string instead of throwing.
+ *
+ * @param {*} data Raw response body (string when coming from Axios)
+ * @return {*} Parsed value with BigInt for large integers, or the input unchanged
+ */
+export function parseJsonBigInt(data) {
+  if (typeof data !== 'string' || data.length === 0) {
+    return data;
+  }
+
+  try {
+    return hathorLib.bigIntUtils.JSONBigInt.parse(data);
+  } catch (e) {
+    return data;
+  }
+}
+
+export default parseJsonBigInt;

--- a/src/api/jsonBigIntResponse.test.js
+++ b/src/api/jsonBigIntResponse.test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { parseJsonBigInt } from './jsonBigIntResponse';
+
+// The full '@hathor/wallet-lib' entrypoint performs heavy initialization that
+// hangs a plain Node/Jest import. We only need the (real) bigint utilities, so
+// we map the package's `bigIntUtils` to its lightweight submodule. The parsing
+// under test is the real JSONBigInt implementation, not a fake. babel-jest
+// hoists this jest.mock above the import at transform time.
+jest.mock('@hathor/wallet-lib', () => ({
+  __esModule: true,
+  // eslint-disable-next-line global-require
+  default: { bigIntUtils: require('@hathor/wallet-lib/lib/utils/bigint') },
+}));
+
+describe('parseJsonBigInt', () => {
+  it('parses integers above Number.MAX_SAFE_INTEGER as exact BigInt', () => {
+    const result = parseJsonBigInt('{"value": 1234567890123456789}');
+    expect(result.value).toBe(1234567890123456789n);
+  });
+
+  it('keeps integers within the safe range as Number', () => {
+    const result = parseJsonBigInt('{"value": 500}');
+    expect(result.value).toBe(500);
+    expect(typeof result.value).toBe('number');
+  });
+
+  it('returns the raw string unchanged for non-JSON bodies', () => {
+    const dot = 'digraph { a -> b }';
+    expect(parseJsonBigInt(dot)).toBe(dot);
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(parseJsonBigInt('')).toBe('');
+  });
+
+  it('returns non-string input unchanged', () => {
+    const alreadyParsed = { value: 1n };
+    expect(parseJsonBigInt(alreadyParsed)).toBe(alreadyParsed);
+  });
+});

--- a/src/api/txApi.js
+++ b/src/api/txApi.js
@@ -7,6 +7,7 @@
 
 import { txApi as libTxApi } from '@hathor/wallet-lib';
 import requestExplorerServiceV1 from './axiosInstance';
+import { parseJsonBigInt } from './jsonBigIntResponse';
 import helpers from '../utils/helpers';
 
 /**
@@ -127,8 +128,8 @@ const txApi = {
     return new Promise((resolve, reject) => {
       libTxApi
         .getTransactions(type, count, timestamp, hash, page, data => {
-          // Parse response if it's a string
-          const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+          // Parse response preserving full integer precision (BigInt for large amounts)
+          const parsedData = parseJsonBigInt(data);
           resolve(parsedData);
         })
         .catch(err => reject(err));

--- a/src/components/AddressHistoryLegacy.js
+++ b/src/components/AddressHistoryLegacy.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import PaginationURL from '../utils/pagination';
 import dateFormatter from '../utils/date';
+import { calculateAddressBalance } from '../utils/addressBalance';
 
 const mapStateToProps = state => ({
   decimalPlaces: state.serverInfo.decimal_places,
@@ -23,30 +24,15 @@ class AddressHistory extends React.Component {
    *
    * @param {Object} tx Transaction data
    *
-   * @return {Number} Final tx balance value (can be negative value, in case we spent more than received for the search address)
+   * @return {bigint} Final tx balance value (can be negative value, in case we spent more than received for the search address)
    */
-  calculateAddressBalance = tx => {
-    const token = this.props.selectedToken;
-    let value = 0;
-
-    for (const txin of tx.inputs) {
-      if (txin.token === token && txin.decoded.address === this.props.address) {
-        if (!hathorLib.transactionUtils.isAuthorityOutput(txin)) {
-          value -= txin.value;
-        }
-      }
-    }
-
-    for (const txout of tx.outputs) {
-      if (txout.token === token && txout.decoded.address === this.props.address) {
-        if (!hathorLib.transactionUtils.isAuthorityOutput(txout)) {
-          value += txout.value;
-        }
-      }
-    }
-
-    return value;
-  };
+  calculateAddressBalance = tx =>
+    calculateAddressBalance(
+      tx,
+      this.props.selectedToken,
+      this.props.address,
+      hathorLib.transactionUtils.isAuthorityOutput.bind(hathorLib.transactionUtils)
+    );
 
   /**
    * Check if the tx has only inputs and outputs that are authorities in the search address

--- a/src/components/AddressSummary.js
+++ b/src/components/AddressSummary.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import { numberUtils } from '@hathor/wallet-lib';
 import { connect } from 'react-redux';
 import HathorSelect from './HathorSelect';
+import { subtractValues } from '../utils/valueMath';
 
 const mapStateToProps = state => ({
   decimalPlaces: state.serverInfo.decimal_places,
@@ -96,9 +97,11 @@ class AddressSummary extends React.Component {
             <div className="address-container-title">Total spent</div>
             <div>
               {renderValue(
-                this.props.balance.total_received -
-                  this.props.balance.unlocked_balance -
+                subtractValues(
+                  this.props.balance.total_received,
+                  this.props.balance.unlocked_balance,
                   this.props.balance.locked_balance
+                )
               )}
             </div>
           </div>

--- a/src/components/AddressSummaryLegacy.js
+++ b/src/components/AddressSummaryLegacy.js
@@ -9,6 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { numberUtils } from '@hathor/wallet-lib';
+import { subtractValues } from '../utils/valueMath';
 
 const mapStateToProps = state => ({
   decimalPlaces: state.serverInfo.decimal_places,
@@ -78,7 +79,7 @@ class AddressSummary extends React.Component {
             Total spent: {renderValue(balance.spent)}
             <br />
             <strong>Final balance: </strong>
-            {renderValue(balance.received - balance.spent)}
+            {renderValue(subtractValues(balance.received, balance.spent))}
           </div>
         </div>
       );

--- a/src/screens/nano/NanoContractLogs.js
+++ b/src/screens/nano/NanoContractLogs.js
@@ -7,6 +7,7 @@
 
 import React, { useEffect, useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
+import hathorLib from '@hathor/wallet-lib';
 import hljs from 'highlight.js/lib/core';
 import json from 'highlight.js/lib/languages/json';
 import nanoApi from '../../api/nanoApi';
@@ -80,7 +81,7 @@ function NanoContractLogs() {
         <div className="blueprint-source-code">
           <pre>
             <code ref={logsRef} className="language-json">
-              {JSON.stringify(logsResponse.logs, null, 2)}
+              {hathorLib.bigIntUtils.JSONBigInt.stringify(logsResponse.logs, 2)}
             </code>
           </pre>
         </div>

--- a/src/utils/addressBalance.js
+++ b/src/utils/addressBalance.js
@@ -23,13 +23,13 @@ export function calculateAddressBalance(tx, token, address, isAuthorityOutput) {
   let value = 0n;
 
   for (const txin of tx.inputs) {
-    if (txin.token === token && txin.decoded.address === address && !isAuthorityOutput(txin)) {
+    if (txin.token === token && txin.decoded?.address === address && !isAuthorityOutput(txin)) {
       value -= BigInt(txin.value);
     }
   }
 
   for (const txout of tx.outputs) {
-    if (txout.token === token && txout.decoded.address === address && !isAuthorityOutput(txout)) {
+    if (txout.token === token && txout.decoded?.address === address && !isAuthorityOutput(txout)) {
       value += BigInt(txout.value);
     }
   }

--- a/src/utils/addressBalance.js
+++ b/src/utils/addressBalance.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Compute the net balance a transaction produced for a given token and address,
+ * with full integer precision (BigInt).
+ *
+ * Amount values may arrive as Number (safe range) or BigInt (large, from
+ * JSONBigInt parsing), so each is normalized to BigInt before accumulating to
+ * avoid precision loss and "cannot mix BigInt and other types" errors.
+ *
+ * @param {Object} tx Transaction data with `inputs` and `outputs`
+ * @param {string} token Selected token uid
+ * @param {string} address Address to compute the balance for
+ * @param {function} isAuthorityOutput Predicate telling whether an input/output is an authority
+ * @return {bigint} Net balance (negative when more was spent than received)
+ */
+export function calculateAddressBalance(tx, token, address, isAuthorityOutput) {
+  let value = 0n;
+
+  for (const txin of tx.inputs) {
+    if (txin.token === token && txin.decoded.address === address && !isAuthorityOutput(txin)) {
+      value -= BigInt(txin.value);
+    }
+  }
+
+  for (const txout of tx.outputs) {
+    if (txout.token === token && txout.decoded.address === address && !isAuthorityOutput(txout)) {
+      value += BigInt(txout.value);
+    }
+  }
+
+  return value;
+}
+
+export default calculateAddressBalance;

--- a/src/utils/addressBalance.test.js
+++ b/src/utils/addressBalance.test.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { calculateAddressBalance } from './addressBalance';
+
+const addr = 'HAddress';
+const token = '00';
+const notAuthority = () => false;
+
+const io = (value, { address = addr, tokenUid = token } = {}) => ({
+  value,
+  token: tokenUid,
+  decoded: { address },
+});
+
+describe('calculateAddressBalance', () => {
+  it('returns outputs minus inputs for the selected token/address as BigInt', () => {
+    const tx = { inputs: [io(200)], outputs: [io(500)] };
+    expect(calculateAddressBalance(tx, token, addr, notAuthority)).toBe(300n);
+  });
+
+  it('preserves precision for values above Number.MAX_SAFE_INTEGER', () => {
+    const tx = {
+      inputs: [io(1000000000000000000n)],
+      outputs: [io(3000000000000000000n)],
+    };
+    expect(calculateAddressBalance(tx, token, addr, notAuthority)).toBe(2000000000000000000n);
+  });
+
+  it('ignores authority outputs', () => {
+    const isAuthority = entry => entry.value === 999n;
+    const tx = { inputs: [], outputs: [io(999n), io(500)] };
+    expect(calculateAddressBalance(tx, token, addr, isAuthority)).toBe(500n);
+  });
+
+  it('ignores entries for other tokens or addresses', () => {
+    const tx = {
+      inputs: [io(100, { address: 'Other' })],
+      outputs: [io(700, { tokenUid: '01' }), io(400)],
+    };
+    expect(calculateAddressBalance(tx, token, addr, notAuthority)).toBe(400n);
+  });
+});

--- a/src/utils/addressBalance.test.js
+++ b/src/utils/addressBalance.test.js
@@ -44,4 +44,12 @@ describe('calculateAddressBalance', () => {
     };
     expect(calculateAddressBalance(tx, token, addr, notAuthority)).toBe(400n);
   });
+
+  it('skips inputs/outputs without a decoded script instead of throwing', () => {
+    const tx = {
+      inputs: [{ value: 100, token, decoded: undefined }],
+      outputs: [{ value: 300, token, decoded: null }, io(600)],
+    };
+    expect(calculateAddressBalance(tx, token, addr, notAuthority)).toBe(600n);
+  });
 });

--- a/src/utils/valueMath.js
+++ b/src/utils/valueMath.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Subtract a chain of amount operands with full integer precision.
+ *
+ * Amounts arrive as either Number (within the safe range) or BigInt (large,
+ * from JSONBigInt parsing). Native arithmetic throws when the two are mixed and
+ * loses precision above 2^53 for Number. This normalizes every operand to BigInt
+ * so the result is always exact.
+ *
+ * @param {number|bigint|string} minuend Value to subtract from
+ * @param {...(number|bigint|string)} subtrahends Values to subtract
+ * @return {bigint} The exact difference
+ */
+export function subtractValues(minuend, ...subtrahends) {
+  return subtrahends.reduce((acc, value) => acc - BigInt(value), BigInt(minuend));
+}
+
+export default subtractValues;

--- a/src/utils/valueMath.test.js
+++ b/src/utils/valueMath.test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { subtractValues } from './valueMath';
+
+describe('subtractValues', () => {
+  it('subtracts a chain of operands and returns a BigInt', () => {
+    // total spent = total_received - unlocked - locked
+    expect(subtractValues(1000, 300, 200)).toBe(500n);
+  });
+
+  it('preserves exact precision for operands above Number.MAX_SAFE_INTEGER', () => {
+    // 3 * 10^18 - 1 * 10^18 - 1 * 10^18 = 1 * 10^18
+    expect(subtractValues(3000000000000000000n, 1000000000000000000n, 1000000000000000000n)).toBe(
+      1000000000000000000n
+    );
+  });
+
+  it('normalizes mixed Number and BigInt operands without throwing', () => {
+    expect(subtractValues(2000000000000000000n, 500)).toBe(1999999999999999500n);
+  });
+
+  it('supports a single subtrahend (received - spent)', () => {
+    expect(subtractValues(700, 250)).toBe(450n);
+  });
+});


### PR DESCRIPTION
### Acceptance Criteria
The decimal precision changed from 2 to 18 places. The explorer must display these amounts fully and correctly. This PR addresses the frontend so the following screens render full-precision values:

- **Transaction detail**: input, output and fee-paid amounts (overview).
- **Address detail**: total received, total spent, unlocked/locked balance, and the transaction listing (already right-aligned so growing values stay aligned).
- **Token balances**: total, unlocked and locked per address.
- **Token detail**: total supply.

**Root cause & fix.** The display layer was already decimal-aware (`prettyValue` reads `decimal_places` from the node's version API and already supports `BigInt`). The real defect was precision loss upstream: in full mode, Explorer Service responses were parsed with the default `JSON.parse`, which silently rounds any integer above `Number.MAX_SAFE_INTEGER` (~0.009 token at 18 decimals). This PR:

- Parses Explorer Service responses with wallet-lib's `bigIntUtils.JSONBigInt` at the axios boundary, so out-of-safe-range integers stay exact (`BigInt`) while timestamps/heights/counts remain `Number`. Falls back gracefully for empty/non-JSON bodies (e.g. graphviz).
- Makes value arithmetic `BigInt`-safe: address "Total spent" (`total_received - unlocked - locked`), legacy "Final balance" (`received - spent`), and the legacy per-tx balance accumulation (`calculateAddressBalance`).
- Fixes a regression the broader `BigInt` parsing introduces: the nano-contract logs viewer used native `JSON.stringify` (which throws on `BigInt`), now switched to `JSONBigInt.stringify`.
- Adds the repo's first unit tests (parsing, arithmetic, balance calc) and a jest `env` override for test files.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. No new dependencies — reuses wallet-lib's existing `bigIntUtils`.

### Screenshots
<img width="712" height="540" alt="image" src="https://github.com/user-attachments/assets/ed23a37a-1c34-445a-b70e-ff943bb9aa00" />
<img width="471" height="535" alt="image" src="https://github.com/user-attachments/assets/f99f5fea-3a79-47a6-9d40-e03d21f7ff87" />
<img width="463" height="758" alt="image" src="https://github.com/user-attachments/assets/cad9dea9-0191-4817-bb6a-bbd35a555f4b" />
<img width="1493" height="460" alt="image" src="https://github.com/user-attachments/assets/efded9b2-0f61-4e7d-8a66-7d4fe2f0e58a" />
<img width="1424" height="629" alt="image" src="https://github.com/user-attachments/assets/43b7f37e-e5ff-4e78-b9fe-32381d91db0d" />
<img width="1403" height="784" alt="image" src="https://github.com/user-attachments/assets/52e89172-1a7c-48aa-b319-f71b6840e7c9" />
<img width="1430" height="748" alt="image" src="https://github.com/user-attachments/assets/879a9d76-dc31-444a-8821-4e1138044700" />
<img width="1469" height="829" alt="image" src="https://github.com/user-attachments/assets/32f6c8fa-df0c-469f-b952-557c5652a6ab" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved full integer precision when parsing API responses and transaction data, keeping large balances and values accurate.
  - Improved address balance and spending calculations by centralizing BigInt-safe math and correctly excluding authority outputs.
  - Updated Nano contract log JSON rendering to use BigInt-aware stringify for more accurate display.
- **Tests**
  - Added and expanded Jest coverage for BigInt JSON parsing, balance computation, and BigInt-safe subtraction (including mixed numeric inputs and boundary values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->