### PR TITLE
chore: remove the testnet-playground deploy target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,19 +63,6 @@ jobs:
           aws-region: us-east-1
           aws-role: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRoleTestnetIndia
 
-  deploy-testnet-playground-explorer:
-    if: github.ref == 'refs/heads/release'
-    needs: dependencies
-    runs-on: ubuntu-latest
-    steps:
-      # https://github.com/actions/checkout/releases/tag/v4.2.2
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: ./.github/actions/deploy-explorer
-        with:
-          site: testnet-playground
-          aws-region: us-east-1
-          aws-role: arn:aws:iam::438696047887:role/ExplorerGitHubActionsRoleTestnetPlayground
-
   deploy-ekvilibro-testnet-explorer:
     if: github.ref == 'refs/heads/release'
     needs: dependencies

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -78,18 +78,6 @@ case $site in
     S3_BUCKET=hathor-testnet-india-public-explorer
     CLOUDFRONT_ID=E1X9TV08O1DPS6
     ;;
-  testnet-playground)
-    FULLNODE_HOST=node1.playground.testnet.hathor.network
-    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
-    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
-    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.playground.testnet.hathor.network/
-    REACT_APP_TIMESERIES_DASHBOARD_ID=b43188d6-4d17-4167-9080-5181b6ce1346
-    # This one is currently only used to form the names of feature flags,
-    # so it made sense to keep it as testnet
-    REACT_APP_NETWORK=testnet
-    S3_BUCKET=hathor-testnet-playground-public-explorer
-    CLOUDFRONT_ID=E23KE3LYRLVKOQ
-    ;;
   mainnet)
     FULLNODE_HOST=node.explorer.hathor.network
     REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/


### PR DESCRIPTION
The `testnet-playground` network is being decommissioned in [ops-tools#1483](https://github.com/HathorNetwork/ops-tools/issues/1483). Its Kubernetes workloads are gone (phase 3), both GCP fullnodes were destroyed today (phase 7.1), and the explorer's own AWS resources — the CloudFront distribution, the `hathor-testnet-playground-public-explorer` bucket and the `ExplorerGitHubActionsRoleTestnetPlayground` IAM role — are being destroyed right now as phase 5.2.

Once that lands, `deploy-testnet-playground-explorer` would fail on the next push to `release`: the role it assumes no longer exists.

Unlike the equivalent stage in `hathor-explorer-service`, this job only syncs build output to S3 and invalidates CloudFront — it does not create infrastructure, so it could never have recreated the environment. The consequence of leaving it is a red release pipeline, not a resurrected network.

## What changed

- removed the `deploy-testnet-playground-explorer` job from `.github/workflows/deploy.yml`
- removed the `testnet-playground)` case from `scripts/deploy.sh`

No other job depends on it — every deploy job depends only on `dependencies` — so nothing is orphaned. The workflow still parses, `bash -n scripts/deploy.sh` passes, and `git grep -i playground` over the repo now returns nothing.

Worth noting this repo was **not** on the decommission's cross-repo checklist, which listed only `hathor-core`, `hathor-core-api-proxy`, `hathor-wallet-service` and `hathor-explorer-service`. It was found by checking which repos could still deploy into the playground account before deleting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deployment support for the Testnet Playground Explorer.
  * Other deployment jobs and configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->