### PR TITLE
chore: remove the ekvilibro-testnet deploy target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,19 +63,6 @@ jobs:
           aws-region: us-east-1
           aws-role: arn:aws:iam::769498303037:role/ExplorerGitHubActionsRoleTestnetIndia
 
-  deploy-ekvilibro-testnet-explorer:
-    if: github.ref == 'refs/heads/release'
-    needs: dependencies
-    runs-on: ubuntu-latest
-    steps:
-      # https://github.com/actions/checkout/releases/tag/v4.2.2
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: ./.github/actions/deploy-explorer
-        with:
-          site: ekvilibro-testnet
-          aws-region: eu-central-1
-          aws-role: arn:aws:iam::730335348496:role/ExplorerGitHubActionsRoleEkvilibroTestnet
-
   deploy-ekvilibro-mainnet-explorer:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: dependencies

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -36,16 +36,6 @@ case $site in
     REACT_APP_TIMESERIES_DASHBOARD_ID=35379840-e8c5-11ec-a7f2-0fee9be0d8ee
     REACT_APP_NETWORK=testnet
     ;;
-  ekvilibro-testnet)
-    FULLNODE_HOST=node-side-dag.ekvilibro-testnet.hathor.network
-    REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/
-    REACT_APP_WS_URL=wss://$FULLNODE_HOST/v1a/ws/
-    REACT_APP_EXPLORER_SERVICE_BASE_URL=https://explorer-service.ekvilibro-testnet.hathor.network/
-    REACT_APP_TIMESERIES_DASHBOARD_ID=
-    REACT_APP_NETWORK=ekvilibro-testnet
-    S3_BUCKET=hathor-ekvilibro-testnet-public-explorer
-    CLOUDFRONT_ID=E3SRP23QB7K3DQ
-    ;;
   ekvilibro-mainnet)
     FULLNODE_HOST=node-side-dag.ekvilibro-mainnet.hathor.network
     REACT_APP_BASE_URL=https://$FULLNODE_HOST/v1a/


### PR DESCRIPTION
Removes the `ekvilibro-testnet` deploy target. The network is being decommissioned in
[ops-tools#1517](https://github.com/HathorNetwork/ops-tools/issues/1517) — it has no users, and
teardown is approved.

### Why this needs to land before the teardown

`deploy-ekvilibro-testnet-explorer` fires on **any push to `release`**. Until this merges, a routine
release would rebuild the explorer bundle, `aws s3 sync --delete` it into
`hathor-ekvilibro-testnet-public-explorer`, and invalidate CloudFront `E3SRP23QB7K3DQ` — recreating
infrastructure the decommission has just removed.

Merging early is safe: the network has no users, so the deploy target has nothing to serve.

### What changed

- `.github/workflows/deploy.yml` — deleted the `deploy-ekvilibro-testnet-explorer` job
- `scripts/deploy.sh` — deleted the `ekvilibro-testnet)` case

### What is deliberately untouched

`deploy-ekvilibro-mainnet-explorer` deploys to the **same AWS account** (`730335348496`) from the
same workflow. It keeps its own tag gate (`refs/tags/v*`) and its own IAM role
(`ExplorerGitHubActionsRoleEkvilibroMainnet`), and is unchanged. `ekvilibro-mainnet` stays live.

### Verification

- No `ekvilibro-testnet` reference remains under `.github/` or `scripts/`
- All 7 `ekvilibro-mainnet` references preserved
- `deploy.yml` parses; remaining jobs are `dependencies`, `deploy-testnet-india-explorer`,
  `deploy-testnet-playground-explorer`, `deploy-ekvilibro-mainnet-explorer`, `deploy-mainnet-explorer`
- `bash -n scripts/deploy.sh` passes

> Note: PR #521 removes the `testnet-playground` target from these same two files. The hunks are
> separate, so the two merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGPsyUjXZ9xD1QaMjExb6v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed deployment support for the Ekvilibro testnet explorer.
  * The Ekvilibro testnet is no longer available as a selectable deployment target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->