### PR TITLE
feat: serve a real robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+# robots.txt for explorer.hathor.network
+User-agent: *
+Disallow:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -151,9 +151,9 @@ case $command in
       exit 1
     fi
     if [ -n "$aws_profile" ]; then
-      aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/index.html" --profile $aws_profile
+      aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_ID" --paths "/index.html" "/robots.txt" --profile "$aws_profile"
     else
-      aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_ID --paths "/index.html"
+      aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_ID" --paths "/index.html" "/robots.txt"
     fi
     ;;
   start)


### PR DESCRIPTION
## Problem

`https://explorer.hathor.network/robots.txt` returns the SPA's `index.html` instead of a robots file:

```
$ curl -sS -o /dev/null -w "%{http_code} %{size_download} %{content_type}\n" https://explorer.hathor.network/robots.txt
200 555 text/html
```

There is no `robots.txt` object in the bucket, so the CloudFront custom error response that rewrites 403/404 to `/index.html` answers the request. A crawler that asks for crawl directives gets an HTML document it cannot parse, served with `HTTP 200`.

## Change

1. **Add `public/robots.txt`.** CRA copies `public/` into `build/`, and `scripts/deploy.sh` runs `aws s3 sync --delete ./build/ s3://$S3_BUCKET`, so the file lands in the bucket and the path stops resolving to the SPA shell.

   The file allows all crawlers, which matches how the site behaves today. This PR is about `/robots.txt` returning a valid plain-text response, not about changing what is crawlable.

2. **Add `/robots.txt` to the CloudFront invalidation** in `scripts/deploy.sh`, so the new file replaces the previously cached response on deploy.

3. **Quote `"$CLOUDFRONT_ID"` and `"$aws_profile"`** in both invalidation branches. `aws_profile` comes from the third script argument, so an unquoted expansion would split a value containing whitespace into multiple AWS CLI arguments.

## Verification after deploy

```sh
curl -sS -D- https://explorer.hathor.network/robots.txt
# expect: HTTP 200, content-type: text/plain, and the file contents
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)