### PR TITLE
chore: bumps to v0.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hathor-admin",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hathor-admin",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "hasInstallScript": true,
       "dependencies": {
         "@hathor/wallet-lib": "2.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-admin",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=10.0.0"


### PR DESCRIPTION
Version bump for the v0.27.0 release, to be merged into `master` immediately before starting the release process (merging `master` into `release`).

`src/constants.js` reads `VERSION` from `package.json`, so no change is needed there. `MIN_API_VERSION` stays at `0.33.0` — the wallet-lib 2.17.0 upgrade does not require a newer full node API.

### Acceptance Criteria
- #500
- #505
- #512
- #515
- #516
- #521
- #522
- #523

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.